### PR TITLE
Fix delimiter selection in create-issues pagination helper

### DIFF
--- a/tools/create-issues.ps1
+++ b/tools/create-issues.ps1
@@ -58,7 +58,8 @@ function Get-AllPages {
   $page = 1
   $acc = @()
   while ($true) {
-    $url = "$UrlBase" + (if ($UrlBase -like "*?*") { "&" } else { "?" }) + "per_page=100&page=$page"
+    $delimiter = if ($UrlBase -like "*?*") { "&" } else { "?" }
+    $url = "{0}{1}per_page=100&page={2}" -f $UrlBase, $delimiter, $page
     $raw = gh api $url 2>$null
     if (-not $raw) { break }
     $arr = $raw | ConvertFrom-Json


### PR DESCRIPTION
## Summary
- compute the delimiter for paginated GitHub API requests outside of the string concatenation
- rebuild the page URL using the delimiter variable to avoid inline `if` expressions that fail at runtime

## Testing
- powershell -ExecutionPolicy Bypass -File tools/create-issues.ps1 -CsvPath meepleai_backlog/meepleai_backlog.csv -DryRun *(fails: `powershell` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68daaa049a6c8320b6a6ae15e7f4f547