### PR TITLE
Fix pagination delimiter in issue creation tooling

### DIFF
--- a/tools/tests/create-issues.Tests.ps1
+++ b/tools/tests/create-issues.Tests.ps1
@@ -1,0 +1,22 @@
+BeforeAll {
+  . (Join-Path $PSScriptRoot '..' 'create-issues.ps1')
+}
+
+Describe 'Get-AllPages' {
+  BeforeEach {
+    Set-Variable -Name CapturedUrls -Scope Script -Value @()
+    Mock -CommandName Invoke-GitHubApi -MockWith {
+      param([string]$Url)
+      $script:CapturedUrls += $Url
+      '[]'
+    } -Verifiable
+  }
+
+  It 'prefixes per_page query when the base URL lacks parameters' {
+    Get-AllPages -UrlBase 'repos/example/labels' | Out-Null
+    $script:CapturedUrls | Should -Not -BeNullOrEmpty
+    $script:CapturedUrls[0] | Should -Match '\?per_page=100&page=1$'
+    $script:CapturedUrls[0].Split('?')[1] | Should -Match '^per_page='
+    Assert-VerifiableMocks
+  }
+}


### PR DESCRIPTION
## Summary
- ensure `Get-AllPages` composes paginated URLs with an explicit helper so `?per_page=` is added when the base URL lacks a query
- wrap the script body behind an invocation guard and introduce an overridable `Invoke-GitHubApi` for easier testing
- add a small Pester regression test that validates the generated URL for label retrieval

## Testing
- pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File ./tools/create-issues.ps1 -CsvPath /tmp/empty.csv -DryRun

------
https://chatgpt.com/codex/tasks/task_e_68dabddaee788320bb3ce87e10be3ca0