### PR TITLE
Add base CI workflows for web and API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  ci-web:
+    name: Web - Lint, Typecheck, Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/web
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install
+      - name: Lint
+        run: pnpm lint
+      - name: Typecheck
+        run: pnpm typecheck
+      - name: Test
+        run: pnpm test -- --ci
+
+  ci-api:
+    name: API - Build and Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/api
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Restore
+        run: dotnet restore
+      - name: Build
+        run: dotnet build -warnaserror
+      - name: Test
+        run: dotnet test --collect:"XPlat Code Coverage"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # MeepleAI Monorepo
 
+![CI](https://github.com/MeepleAI/meepleai-monorepo/actions/workflows/ci.yml/badge.svg)
+
+
 Questo repository ospita gli stack principali di MeepleAI:
 
 - **apps/web** – front-end Next.js per l'interfaccia degli agenti Meeple.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds, lints, type-checks, and tests the web app
- add API build and test job using .NET 8 to the shared CI workflow
- document the CI status badge in the main README

## Testing
- not run (workflow definitions only)


------
https://chatgpt.com/codex/tasks/task_e_68daccc248c88320a42fc991b0445b59