### PR TITLE
feat: implement session-based authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ erDiagram
 - Le chat devono referenziare sia il gioco (`game_id`) sia il modello di regole (`rule_spec_id`) per il tenant corrente; la cancellazione di un tenant deve propagare tramite cascade verso utenti, giochi, agenti, chat e log per evitare orfani e mantenere l'isolamento. Quando si applicano nuove migrazioni verificare che tutte le FK abbiano `ON DELETE CASCADE` o strategie equivalenti compatibili con RLS.
 - Per la verifica di DB-01 assicurarsi che: (1) tutte le tabelle includano `tenant_id NOT NULL`, (2) gli indici multi-tenant siano presenti, e (3) i dati seed rispettino l'isolamento (nessun record cross-tenant, chat/log sempre filtrati per `tenant_id` e `game_id`).
 
+## Autenticazione e ruoli
+
+- Le API espongono gli endpoint `POST /auth/register`, `POST /auth/login`, `POST /auth/logout` e `GET /auth/me`. La registrazione crea automaticamente il tenant se non esiste e assegna un ruolo (`Admin`, `Editor`, `User`).
+- Le sessioni sono persistite in tabella `user_sessions` con token casuali hashati; il token è inviato al client tramite cookie `HttpOnly`.
+- Gli endpoint protetti (`/agents/qa`, `/ingest/pdf`, `/admin/seed`) richiedono una sessione valida e rispettano i permessi: solo Admin può eseguire il seed, Admin/Editor possono accedere a ingest, tutti i ruoli autenticati possono usare il QA sul proprio tenant.
+
 ## Struttura
 
 ```

--- a/apps/api/src/Api/Infrastructure/Entities/TenantEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/TenantEntity.cs
@@ -13,4 +13,5 @@ public class TenantEntity
     public ICollection<AgentEntity> Agents { get; set; } = new List<AgentEntity>();
     public ICollection<ChatEntity> Chats { get; set; } = new List<ChatEntity>();
     public ICollection<ChatLogEntity> ChatLogs { get; set; } = new List<ChatLogEntity>();
+    public ICollection<UserSessionEntity> Sessions { get; set; } = new List<UserSessionEntity>();
 }

--- a/apps/api/src/Api/Infrastructure/Entities/UserEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/UserEntity.cs
@@ -7,7 +7,10 @@ public class UserEntity
     public string Email { get; set; } = default!;
     public string? DisplayName { get; set; }
         = null;
+    public string PasswordHash { get; set; } = default!;
+    public UserRole Role { get; set; } = UserRole.User;
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
     public TenantEntity Tenant { get; set; } = default!;
+    public ICollection<UserSessionEntity> Sessions { get; set; } = new List<UserSessionEntity>();
 }

--- a/apps/api/src/Api/Infrastructure/Entities/UserRole.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/UserRole.cs
@@ -1,0 +1,8 @@
+namespace Api.Infrastructure.Entities;
+
+public enum UserRole
+{
+    Admin,
+    Editor,
+    User
+}

--- a/apps/api/src/Api/Infrastructure/Entities/UserSessionEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/UserSessionEntity.cs
@@ -1,0 +1,18 @@
+namespace Api.Infrastructure.Entities;
+
+public class UserSessionEntity
+{
+    public string Id { get; set; } = default!;
+    public string TenantId { get; set; } = default!;
+    public string UserId { get; set; } = default!;
+    public string TokenHash { get; set; } = default!;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime ExpiresAt { get; set; };
+    public DateTime? LastSeenAt { get; set; };
+    public DateTime? RevokedAt { get; set; };
+    public string? UserAgent { get; set; };
+    public string? IpAddress { get; set; };
+
+    public TenantEntity Tenant { get; set; } = default!;
+    public UserEntity User { get; set; } = default!;
+}

--- a/apps/api/src/Api/Migrations/20250930120000_AUTH01_AddAuth.Designer.cs
+++ b/apps/api/src/Api/Migrations/20250930120000_AUTH01_AddAuth.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Api.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250930120000_AUTH01_AddAuth")]
+    partial class AUTH01_AddAuth
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Migrations/20250930120000_AUTH01_AddAuth.cs
+++ b/apps/api/src/Api/Migrations/20250930120000_AUTH01_AddAuth.cs
@@ -1,0 +1,88 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AUTH01_AddAuth : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PasswordHash",
+                table: "users",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Role",
+                table: "users",
+                type: "character varying(32)",
+                maxLength: 32,
+                nullable: false,
+                defaultValue: "User");
+
+            migrationBuilder.CreateTable(
+                name: "user_sessions",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    TenantId = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    UserId = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    TokenHash = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ExpiresAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    LastSeenAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    RevokedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    UserAgent = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    IpAddress = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_user_sessions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_user_sessions_tenants_TenantId",
+                        column: x => x.TenantId,
+                        principalTable: "tenants",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_user_sessions_users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_user_sessions_TenantId_UserId",
+                table: "user_sessions",
+                columns: new[] { "TenantId", "UserId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_user_sessions_TokenHash",
+                table: "user_sessions",
+                column: "TokenHash",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "user_sessions");
+
+            migrationBuilder.DropColumn(
+                name: "PasswordHash",
+                table: "users");
+
+            migrationBuilder.DropColumn(
+                name: "Role",
+                table: "users");
+        }
+    }
+}

--- a/apps/api/src/Api/Models/AuthContracts.cs
+++ b/apps/api/src/Api/Models/AuthContracts.cs
@@ -1,0 +1,41 @@
+namespace Api.Models;
+
+public record RegisterPayload(
+    string tenantId,
+    string email,
+    string password,
+    string? displayName,
+    string? role,
+    string? tenantName);
+
+public record LoginPayload(string tenantId, string email, string password);
+
+public record RegisterCommand(
+    string tenantId,
+    string? tenantName,
+    string email,
+    string password,
+    string? displayName,
+    string? role,
+    string? ipAddress,
+    string? userAgent);
+
+public record LoginCommand(
+    string tenantId,
+    string email,
+    string password,
+    string? ipAddress,
+    string? userAgent);
+
+public record AuthUser(
+    string id,
+    string tenantId,
+    string email,
+    string? displayName,
+    string role);
+
+public record AuthResult(AuthUser User, string SessionToken, DateTime ExpiresAt);
+
+public record ActiveSession(AuthUser User, DateTime ExpiresAt);
+
+public record AuthResponse(AuthUser user, DateTime expiresAt);

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -1,4 +1,6 @@
 using Api.Infrastructure;
+using System.Security.Claims;
+using Api.Infrastructure.Entities;
 using Api.Models;
 using Api.Services;
 using Microsoft.EntityFrameworkCore;
@@ -15,6 +17,26 @@ builder.Services.AddDbContext<MeepleAiDbContext>(options =>
 
 builder.Services.AddScoped<RuleSpecService>();
 builder.Services.AddScoped<RagService>();
+builder.Services.AddScoped<AuthService>();
+
+var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? Array.Empty<string>();
+
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("web", policy =>
+    {
+        if (allowedOrigins.Length == 0)
+        {
+            policy.WithOrigins("http://localhost:3000");
+        }
+        else
+        {
+            policy.WithOrigins(allowedOrigins);
+        }
+
+        policy.AllowAnyHeader().AllowAnyMethod().AllowCredentials();
+    });
+});
 
 var app = builder.Build();
 
@@ -24,21 +46,160 @@ using (var scope = app.Services.CreateScope())
     db.Database.Migrate();
 }
 
+app.UseCors("web");
+
+app.Use(async (context, next) =>
+{
+    if (context.Request.Cookies.TryGetValue(AuthService.SessionCookieName, out var token) &&
+        !string.IsNullOrWhiteSpace(token))
+    {
+        var auth = context.RequestServices.GetRequiredService<AuthService>();
+        var session = await auth.ValidateSessionAsync(token, context.RequestAborted);
+        if (session != null)
+        {
+            var claims = new List<Claim>
+            {
+                new(ClaimTypes.NameIdentifier, session.User.id),
+                new(ClaimTypes.Email, session.User.email),
+                new("tenant", session.User.tenantId),
+                new("displayName", session.User.displayName ?? string.Empty),
+                new(ClaimTypes.Role, session.User.role)
+            };
+            var identity = new ClaimsIdentity(claims, "session");
+            context.User = new ClaimsPrincipal(identity);
+            context.Items[nameof(ActiveSession)] = session;
+        }
+    }
+
+    await next();
+});
+
 app.MapGet("/", () => Results.Json(new { ok = true, name = "MeepleAgentAI" }));
 
-app.MapPost("/agents/qa", async (QaRequest req, RagService rag, CancellationToken ct) =>
+app.MapPost("/auth/register", async (RegisterPayload payload, HttpContext context, AuthService auth, CancellationToken ct) =>
 {
+    try
+    {
+        var command = new RegisterCommand(
+            payload.tenantId,
+            payload.tenantName,
+            payload.email,
+            payload.password,
+            payload.displayName,
+            payload.role,
+            context.Connection.RemoteIpAddress?.ToString(),
+            context.Request.Headers.UserAgent.ToString());
+
+        var result = await auth.RegisterAsync(command, ct);
+        WriteSessionCookie(context, result.SessionToken, result.ExpiresAt);
+        return Results.Json(new AuthResponse(result.User, result.ExpiresAt));
+    }
+    catch (ArgumentException ex)
+    {
+        return Results.BadRequest(new { error = ex.Message });
+    }
+    catch (InvalidOperationException ex)
+    {
+        return Results.Conflict(new { error = ex.Message });
+    }
+});
+
+app.MapPost("/auth/login", async (LoginPayload payload, HttpContext context, AuthService auth, CancellationToken ct) =>
+{
+    var command = new LoginCommand(
+        payload.tenantId,
+        payload.email,
+        payload.password,
+        context.Connection.RemoteIpAddress?.ToString(),
+        context.Request.Headers.UserAgent.ToString());
+
+    var result = await auth.LoginAsync(command, ct);
+    if (result == null)
+    {
+        RemoveSessionCookie(context);
+        return Results.Unauthorized(new { error = "Invalid credentials" });
+    }
+
+    WriteSessionCookie(context, result.SessionToken, result.ExpiresAt);
+    return Results.Json(new AuthResponse(result.User, result.ExpiresAt));
+});
+
+app.MapPost("/auth/logout", async (HttpContext context, AuthService auth, CancellationToken ct) =>
+{
+    if (context.Request.Cookies.TryGetValue(AuthService.SessionCookieName, out var token) &&
+        !string.IsNullOrWhiteSpace(token))
+    {
+        await auth.LogoutAsync(token, ct);
+    }
+
+    RemoveSessionCookie(context);
+    return Results.Json(new { ok = true });
+});
+
+app.MapGet("/auth/me", (HttpContext context) =>
+{
+    if (context.Items.TryGetValue(nameof(ActiveSession), out var value) && value is ActiveSession session)
+    {
+        return Results.Json(new AuthResponse(session.User, session.ExpiresAt));
+    }
+
+    return Results.Unauthorized();
+});
+
+app.MapPost("/agents/qa", async (QaRequest req, HttpContext context, RagService rag, CancellationToken ct) =>
+{
+    if (!context.Items.TryGetValue(nameof(ActiveSession), out var value) || value is not ActiveSession session)
+    {
+        return Results.Unauthorized();
+    }
+
+    if (!string.Equals(req.tenantId, session.User.tenantId, StringComparison.Ordinal))
+    {
+        return Results.Forbid();
+    }
+
     if (string.IsNullOrWhiteSpace(req.tenantId) || string.IsNullOrWhiteSpace(req.gameId))
+    {
         return Results.BadRequest(new { error = "tenantId and gameId are required" });
+    }
 
     var resp = await rag.AskAsync(req.tenantId, req.gameId, req.query, ct);
     return Results.Json(resp);
 });
 
-app.MapPost("/ingest/pdf", () => Results.Json(new IngestPdfResponse(Guid.NewGuid().ToString("N"))));
-
-app.MapPost("/admin/seed", async (SeedRequest request, RuleSpecService rules, CancellationToken ct) =>
+app.MapPost("/ingest/pdf", (HttpContext context) =>
 {
+    if (!context.Items.TryGetValue(nameof(ActiveSession), out var value) || value is not ActiveSession session)
+    {
+        return Results.Unauthorized();
+    }
+
+    if (!string.Equals(session.User.role, UserRole.Admin.ToString(), StringComparison.OrdinalIgnoreCase) &&
+        !string.Equals(session.User.role, UserRole.Editor.ToString(), StringComparison.OrdinalIgnoreCase))
+    {
+        return Results.Forbid();
+    }
+
+    return Results.Json(new IngestPdfResponse(Guid.NewGuid().ToString("N")));
+});
+
+app.MapPost("/admin/seed", async (SeedRequest request, HttpContext context, RuleSpecService rules, CancellationToken ct) =>
+{
+    if (!context.Items.TryGetValue(nameof(ActiveSession), out var value) || value is not ActiveSession session)
+    {
+        return Results.Unauthorized();
+    }
+
+    if (!string.Equals(session.User.role, UserRole.Admin.ToString(), StringComparison.OrdinalIgnoreCase))
+    {
+        return Results.Forbid();
+    }
+
+    if (!string.Equals(session.User.tenantId, request.tenantId, StringComparison.Ordinal))
+    {
+        return Results.Forbid();
+    }
+
     if (string.IsNullOrWhiteSpace(request.tenantId) || string.IsNullOrWhiteSpace(request.gameId))
     {
         return Results.BadRequest(new { error = "tenantId and gameId are required" });
@@ -49,3 +210,31 @@ app.MapPost("/admin/seed", async (SeedRequest request, RuleSpecService rules, Ca
 });
 
 app.Run();
+
+static void WriteSessionCookie(HttpContext context, string token, DateTime expiresAt)
+{
+    var options = new CookieOptions
+    {
+        HttpOnly = true,
+        Secure = context.Request.IsHttps,
+        SameSite = SameSiteMode.Strict,
+        Path = "/",
+        Expires = new DateTimeOffset(expiresAt)
+    };
+
+    context.Response.Cookies.Append(AuthService.SessionCookieName, token, options);
+}
+
+static void RemoveSessionCookie(HttpContext context)
+{
+    var options = new CookieOptions
+    {
+        HttpOnly = true,
+        Secure = context.Request.IsHttps,
+        SameSite = SameSiteMode.Strict,
+        Path = "/",
+        Expires = DateTimeOffset.UnixEpoch
+    };
+
+    context.Response.Cookies.Delete(AuthService.SessionCookieName, options);
+}

--- a/apps/api/src/Api/Services/AuthService.cs
+++ b/apps/api/src/Api/Services/AuthService.cs
@@ -1,0 +1,236 @@
+using System.Security.Cryptography;
+using System.Text;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.Services;
+
+public class AuthService
+{
+    public const string SessionCookieName = "meeple_session";
+    private const int SessionTokenSize = 32;
+    private static readonly TimeSpan SessionLifetime = TimeSpan.FromDays(7);
+    private readonly MeepleAiDbContext _db;
+    private readonly TimeProvider _timeProvider;
+
+    public AuthService(MeepleAiDbContext db, TimeProvider? timeProvider = null)
+    {
+        _db = db;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    public async Task<AuthResult> RegisterAsync(RegisterCommand command, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(command.tenantId))
+            throw new ArgumentException("TenantId is required", nameof(command.tenantId));
+        if (string.IsNullOrWhiteSpace(command.email))
+            throw new ArgumentException("Email is required", nameof(command.email));
+        if (string.IsNullOrWhiteSpace(command.password) || command.password.Length < 8)
+            throw new ArgumentException("Password must be at least 8 characters", nameof(command.password));
+
+        var normalizedTenantId = command.tenantId.Trim();
+        var email = command.email.Trim().ToLowerInvariant();
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+
+        var tenant = await _db.Tenants.FirstOrDefaultAsync(t => t.Id == normalizedTenantId, ct);
+        if (tenant == null)
+        {
+            tenant = new TenantEntity
+            {
+                Id = normalizedTenantId,
+                Name = string.IsNullOrWhiteSpace(command.tenantName)
+                    ? normalizedTenantId
+                    : command.tenantName!.Trim(),
+                CreatedAt = now
+            };
+            _db.Tenants.Add(tenant);
+        }
+
+        var existingUser = await _db.Users.FirstOrDefaultAsync(u => u.TenantId == normalizedTenantId && u.Email == email, ct);
+        if (existingUser != null)
+        {
+            throw new InvalidOperationException("Email is already registered for this tenant");
+        }
+
+        var role = ParseRole(command.role);
+
+        var user = new UserEntity
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            TenantId = normalizedTenantId,
+            Email = email,
+            DisplayName = command.displayName?.Trim(),
+            PasswordHash = HashPassword(command.password),
+            Role = role,
+            CreatedAt = now
+        };
+        _db.Users.Add(user);
+
+        var session = CreateSessionEntity(user, command.ipAddress, command.userAgent, now);
+        _db.UserSessions.Add(session.Entity);
+
+        await _db.SaveChangesAsync(ct);
+
+        return new AuthResult(ToDto(user), session.Token, session.Entity.ExpiresAt);
+    }
+
+    public async Task<AuthResult?> LoginAsync(LoginCommand command, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(command.tenantId) || string.IsNullOrWhiteSpace(command.email) ||
+            string.IsNullOrWhiteSpace(command.password))
+        {
+            return null;
+        }
+
+        var tenantId = command.tenantId.Trim();
+        var email = command.email.Trim().ToLowerInvariant();
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+
+        var user = await _db.Users.FirstOrDefaultAsync(u => u.TenantId == tenantId && u.Email == email, ct);
+        if (user == null)
+        {
+            return null;
+        }
+
+        if (!VerifyPassword(command.password, user.PasswordHash))
+        {
+            return null;
+        }
+
+        var session = CreateSessionEntity(user, command.ipAddress, command.userAgent, now);
+        _db.UserSessions.Add(session.Entity);
+        await _db.SaveChangesAsync(ct);
+
+        return new AuthResult(ToDto(user), session.Token, session.Entity.ExpiresAt);
+    }
+
+    public async Task<ActiveSession?> ValidateSessionAsync(string token, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return null;
+        }
+
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var hash = HashToken(token);
+
+        var session = await _db.UserSessions
+            .Include(s => s.User)
+            .FirstOrDefaultAsync(s => s.TokenHash == hash, ct);
+
+        if (session == null || session.RevokedAt != null || session.ExpiresAt <= now)
+        {
+            return null;
+        }
+
+        session.LastSeenAt = now;
+        await _db.SaveChangesAsync(ct);
+
+        return new ActiveSession(ToDto(session.User), session.ExpiresAt);
+    }
+
+    public async Task LogoutAsync(string token, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return;
+        }
+
+        var hash = HashToken(token);
+        var session = await _db.UserSessions.FirstOrDefaultAsync(s => s.TokenHash == hash, ct);
+        if (session == null)
+        {
+            return;
+        }
+
+        session.RevokedAt = _timeProvider.GetUtcNow().UtcDateTime;
+        await _db.SaveChangesAsync(ct);
+    }
+
+    private static (UserSessionEntity Entity, string Token) CreateSessionEntity(UserEntity user, string? ipAddress, string? userAgent, DateTime now)
+    {
+        var tokenBytes = RandomNumberGenerator.GetBytes(SessionTokenSize);
+        var token = Convert.ToBase64String(tokenBytes);
+        var expires = now.Add(SessionLifetime);
+
+        var entity = new UserSessionEntity
+        {
+            Id = Guid.NewGuid().ToString("N"),
+            TenantId = user.TenantId,
+            UserId = user.Id,
+            TokenHash = HashToken(token),
+            CreatedAt = now,
+            ExpiresAt = expires,
+            LastSeenAt = now,
+            IpAddress = ipAddress,
+            UserAgent = userAgent
+        };
+
+        return (entity, token);
+    }
+
+    private static string HashPassword(string password)
+    {
+        const int iterations = 210_000;
+        var salt = RandomNumberGenerator.GetBytes(16);
+        var hash = Rfc2898DeriveBytes.Pbkdf2(password, salt, iterations, HashAlgorithmName.SHA256, 32);
+        return $"v1.{iterations}.{Convert.ToBase64String(salt)}.{Convert.ToBase64String(hash)}";
+    }
+
+    private static bool VerifyPassword(string password, string encodedHash)
+    {
+        try
+        {
+            var parts = encodedHash.Split('.', StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length != 4 || parts[0] != "v1")
+            {
+                return false;
+            }
+
+            if (!int.TryParse(parts[1], out var iterations))
+            {
+                return false;
+            }
+
+            var salt = Convert.FromBase64String(parts[2]);
+            var expected = Convert.FromBase64String(parts[3]);
+
+            var hash = Rfc2898DeriveBytes.Pbkdf2(password, salt, iterations, HashAlgorithmName.SHA256, expected.Length);
+            return CryptographicOperations.FixedTimeEquals(hash, expected);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    private static string HashToken(string token)
+    {
+        var bytes = Encoding.UTF8.GetBytes(token);
+        var hash = SHA256.HashData(bytes);
+        return Convert.ToBase64String(hash);
+    }
+
+    private static AuthUser ToDto(UserEntity user) => new(
+        user.Id,
+        user.TenantId,
+        user.Email,
+        user.DisplayName,
+        user.Role.ToString());
+
+    private static UserRole ParseRole(string? role)
+    {
+        if (string.IsNullOrWhiteSpace(role))
+        {
+            return UserRole.User;
+        }
+
+        return Enum.TryParse<UserRole>(role, true, out var parsed) ? parsed : UserRole.User;
+    }
+}

--- a/apps/api/tests/Api.Tests/AuthServiceTests.cs
+++ b/apps/api/tests/Api.Tests/AuthServiceTests.cs
@@ -1,0 +1,82 @@
+using Api.Infrastructure;
+using Api.Models;
+using Api.Services;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+public class AuthServiceTests
+{
+    [Fact]
+    public async Task RegisterLoginLogout_RoundTrip_Succeeds()
+    {
+        await using var connection = new SqliteConnection("Filename=:memory:");
+        await connection.OpenAsync();
+
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        await using (var setupContext = new MeepleAiDbContext(options))
+        {
+            await setupContext.Database.EnsureCreatedAsync();
+        }
+
+        await using var dbContext = new MeepleAiDbContext(options);
+        var timeProvider = new FixedTimeProvider(DateTimeOffset.Parse("2024-01-01T00:00:00Z"));
+        var authService = new AuthService(dbContext, timeProvider);
+
+        var register = await authService.RegisterAsync(new RegisterCommand(
+            "tenant-test",
+            "Tenant Test",
+            "user@example.com",
+            "Password!1",
+            "Test User",
+            "Admin",
+            "127.0.0.1",
+            "unit-tests"));
+
+        Assert.Equal("tenant-test", register.User.tenantId);
+        Assert.Equal("Admin", register.User.role);
+        Assert.False(string.IsNullOrWhiteSpace(register.SessionToken));
+
+        var active = await authService.ValidateSessionAsync(register.SessionToken);
+        Assert.NotNull(active);
+        Assert.Equal(register.User.email, active!.User.email);
+
+        await authService.LogoutAsync(register.SessionToken);
+        var afterLogout = await authService.ValidateSessionAsync(register.SessionToken);
+        Assert.Null(afterLogout);
+
+        var login = await authService.LoginAsync(new LoginCommand(
+            "tenant-test",
+            "user@example.com",
+            "Password!1",
+            null,
+            null));
+
+        Assert.NotNull(login);
+        Assert.Equal(register.User.id, login!.User.id);
+        Assert.NotEqual(register.SessionToken, login.SessionToken);
+
+        var failedLogin = await authService.LoginAsync(new LoginCommand(
+            "tenant-test",
+            "user@example.com",
+            "wrong",
+            null,
+            null));
+        Assert.Null(failedLogin);
+    }
+
+    private sealed class FixedTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _now;
+
+        public FixedTimeProvider(DateTimeOffset now)
+        {
+            _now = now;
+        }
+
+        public override DateTimeOffset GetUtcNow() => _now;
+    }
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,11 +1,24 @@
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE || "http://localhost:8080";
 export const api = {
-  async post(path: string, body: unknown) {
+  async get<T>(path: string): Promise<T | null> {
+    const res = await fetch(`${API_BASE}${path}`, {
+      method: "GET",
+      credentials: "include"
+    });
+    if (res.status === 401) return null;
+    if (!res.ok) throw new Error(`API ${path} ${res.status}`);
+    return res.json();
+  },
+  async post<T>(path: string, body?: unknown): Promise<T> {
     const res = await fetch(`${API_BASE}${path}`, {
       method: "POST",
+      credentials: "include",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body)
+      body: JSON.stringify(body ?? {})
     });
+    if (res.status === 401) {
+      throw new Error("Unauthorized");
+    }
     if (!res.ok) throw new Error(`API ${path} ${res.status}`);
     return res.json();
   }

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -1,8 +1,57 @@
-import { useState } from "react";
+import { FormEvent, useEffect, useState } from "react";
 import { api } from "../lib/api";
+
+type AuthUser = {
+  id: string;
+  tenantId: string;
+  email: string;
+  displayName?: string | null;
+  role: string;
+};
+
+type AuthResponse = {
+  user: AuthUser;
+  expiresAt: string;
+};
+
+const DEFAULT_TENANT = process.env.NEXT_PUBLIC_TENANT_ID || "dev";
 
 export default function Home() {
   const [answer, setAnswer] = useState<string>("");
+  const [authUser, setAuthUser] = useState<AuthUser | null>(null);
+  const [statusMessage, setStatusMessage] = useState<string>("");
+  const [errorMessage, setErrorMessage] = useState<string>("");
+  const [registerForm, setRegisterForm] = useState({
+    tenantId: DEFAULT_TENANT,
+    tenantName: "",
+    email: "",
+    password: "",
+    displayName: "",
+    role: "User"
+  });
+  const [loginForm, setLoginForm] = useState({
+    tenantId: DEFAULT_TENANT,
+    email: "",
+    password: ""
+  });
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    void loadCurrentUser();
+  }, []);
+
+  const loadCurrentUser = async () => {
+    try {
+      const res = await api.get<AuthResponse>("/auth/me");
+      if (res) {
+        setAuthUser(res.user);
+      } else {
+        setAuthUser(null);
+      }
+    } catch {
+      setAuthUser(null);
+    }
+  };
 
   const ping = async () => {
     const res = await fetch("/api/health");
@@ -11,21 +60,228 @@ export default function Home() {
   };
 
   const ask = async () => {
-    const res = await api.post("/agents/qa", {
-      tenantId: process.env.NEXT_PUBLIC_TENANT_ID,
-      gameId: "demo-chess",
-      query: "How many players?"
-    });
-    setAnswer(res.answer);
+    if (!authUser) {
+      setErrorMessage("Devi effettuare l'accesso per porre domande.");
+      return;
+    }
+    setErrorMessage("");
+    setIsLoading(true);
+    try {
+      const res = await api.post<{ answer: string }>("/agents/qa", {
+        tenantId: authUser.tenantId,
+        gameId: "demo-chess",
+        query: "How many players?"
+      });
+      setAnswer(res.answer);
+      setStatusMessage("Risposta aggiornata.");
+    } catch (err) {
+      console.error(err);
+      setErrorMessage("Impossibile interrogare l'agente. Controlla le credenziali.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleRegister = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setErrorMessage("");
+    try {
+      const payload = {
+        tenantId: registerForm.tenantId,
+        tenantName: registerForm.tenantName || undefined,
+        email: registerForm.email,
+        password: registerForm.password,
+        displayName: registerForm.displayName || undefined,
+        role: registerForm.role
+      };
+      const res = await api.post<AuthResponse>("/auth/register", payload);
+      setAuthUser(res.user);
+      setStatusMessage("Registrazione completata. Sei connesso!");
+      setRegisterForm({
+        tenantId: registerForm.tenantId,
+        tenantName: "",
+        email: "",
+        password: "",
+        displayName: "",
+        role: "User"
+      });
+    } catch (err: any) {
+      console.error(err);
+      setErrorMessage(err?.message || "Registrazione non riuscita.");
+    }
+  };
+
+  const handleLogin = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setErrorMessage("");
+    try {
+      const res = await api.post<AuthResponse>("/auth/login", {
+        tenantId: loginForm.tenantId,
+        email: loginForm.email,
+        password: loginForm.password
+      });
+      setAuthUser(res.user);
+      setStatusMessage("Accesso eseguito.");
+      setLoginForm({ tenantId: loginForm.tenantId, email: "", password: "" });
+    } catch (err: any) {
+      console.error(err);
+      setErrorMessage(err?.message || "Accesso non riuscito.");
+    }
+  };
+
+  const logout = async () => {
+    try {
+      await api.post("/auth/logout");
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setAuthUser(null);
+      setStatusMessage("Sessione terminata.");
+    }
   };
 
   return (
-    <main style={{ padding: 24 }}>
+    <main style={{ padding: 24, maxWidth: 800, margin: "0 auto", fontFamily: "sans-serif" }}>
       <h1>MeepleAI</h1>
       <p>Frontend ↔ MeepleAgentAI</p>
-      <button onClick={ping}>Ping Web</button>
-      <button onClick={ask} style={{ marginLeft: 12 }}>Ask QA</button>
-      <pre>{answer}</pre>
+
+      {statusMessage && <p style={{ color: "#0070f3" }}>{statusMessage}</p>}
+      {errorMessage && <p style={{ color: "#d93025" }}>{errorMessage}</p>}
+
+      <section style={{ display: "flex", gap: 24, flexWrap: "wrap" }}>
+        <form onSubmit={handleRegister} style={{ flex: "1 1 320px", border: "1px solid #ccc", padding: 16, borderRadius: 8 }}>
+          <h2>Registrazione</h2>
+          <label style={{ display: "block", marginBottom: 8 }}>
+            Tenant ID
+            <input
+              value={registerForm.tenantId}
+              onChange={(e) => setRegisterForm({ ...registerForm, tenantId: e.target.value })}
+              style={{ width: "100%" }}
+              required
+            />
+          </label>
+          <label style={{ display: "block", marginBottom: 8 }}>
+            Nome Tenant
+            <input
+              value={registerForm.tenantName}
+              onChange={(e) => setRegisterForm({ ...registerForm, tenantName: e.target.value })}
+              style={{ width: "100%" }}
+            />
+          </label>
+          <label style={{ display: "block", marginBottom: 8 }}>
+            Email
+            <input
+              type="email"
+              value={registerForm.email}
+              onChange={(e) => setRegisterForm({ ...registerForm, email: e.target.value })}
+              style={{ width: "100%" }}
+              required
+            />
+          </label>
+          <label style={{ display: "block", marginBottom: 8 }}>
+            Password (min 8 caratteri)
+            <input
+              type="password"
+              value={registerForm.password}
+              onChange={(e) => setRegisterForm({ ...registerForm, password: e.target.value })}
+              style={{ width: "100%" }}
+              required
+              minLength={8}
+            />
+          </label>
+          <label style={{ display: "block", marginBottom: 8 }}>
+            Nome visualizzato
+            <input
+              value={registerForm.displayName}
+              onChange={(e) => setRegisterForm({ ...registerForm, displayName: e.target.value })}
+              style={{ width: "100%" }}
+            />
+          </label>
+          <label style={{ display: "block", marginBottom: 12 }}>
+            Ruolo
+            <select
+              value={registerForm.role}
+              onChange={(e) => setRegisterForm({ ...registerForm, role: e.target.value })}
+              style={{ width: "100%" }}
+            >
+              <option value="Admin">Admin</option>
+              <option value="Editor">Editor</option>
+              <option value="User">User</option>
+            </select>
+          </label>
+          <button type="submit">Crea account</button>
+        </form>
+
+        <form onSubmit={handleLogin} style={{ flex: "1 1 320px", border: "1px solid #ccc", padding: 16, borderRadius: 8 }}>
+          <h2>Accesso</h2>
+          <label style={{ display: "block", marginBottom: 8 }}>
+            Tenant ID
+            <input
+              value={loginForm.tenantId}
+              onChange={(e) => setLoginForm({ ...loginForm, tenantId: e.target.value })}
+              style={{ width: "100%" }}
+              required
+            />
+          </label>
+          <label style={{ display: "block", marginBottom: 8 }}>
+            Email
+            <input
+              type="email"
+              value={loginForm.email}
+              onChange={(e) => setLoginForm({ ...loginForm, email: e.target.value })}
+              style={{ width: "100%" }}
+              required
+            />
+          </label>
+          <label style={{ display: "block", marginBottom: 12 }}>
+            Password
+            <input
+              type="password"
+              value={loginForm.password}
+              onChange={(e) => setLoginForm({ ...loginForm, password: e.target.value })}
+              style={{ width: "100%" }}
+              required
+            />
+          </label>
+          <button type="submit">Entra</button>
+          <button type="button" onClick={logout} style={{ marginLeft: 8 }}>
+            Esci
+          </button>
+        </form>
+      </section>
+
+      <section style={{ marginTop: 32 }}>
+        <h2>Sessione corrente</h2>
+        {authUser ? (
+          <div style={{ border: "1px solid #ccc", padding: 16, borderRadius: 8 }}>
+            <p>
+              <strong>Email:</strong> {authUser.email}
+            </p>
+            <p>
+              <strong>Tenant:</strong> {authUser.tenantId}
+            </p>
+            <p>
+              <strong>Ruolo:</strong> {authUser.role}
+            </p>
+            {authUser.displayName && (
+              <p>
+                <strong>Nome:</strong> {authUser.displayName}
+              </p>
+            )}
+          </div>
+        ) : (
+          <p>Nessun utente connesso.</p>
+        )}
+      </section>
+
+      <section style={{ marginTop: 32 }}>
+        <h2>Agente QA Demo</h2>
+        <button onClick={ping}>Ping Web</button>
+        <button onClick={ask} style={{ marginLeft: 12 }} disabled={!authUser || isLoading}>
+          {isLoading ? "Richiesta..." : "Chiedi"}
+        </button>
+        <pre style={{ background: "#f5f5f5", padding: 12, marginTop: 16 }}>{answer}</pre>
+      </section>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add server-side authentication service with hashed passwords, session storage, and supporting migrations
- protect QA/admin endpoints via cookie-backed middleware and expose register/login/logout/me routes
- refresh the web homepage with auth flows and document the new role model

## Testing
- pnpm lint
- dotnet test *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dad8a413708320bf8b1dd84dd10a2a