### PR TITLE
Fix trailing semicolons on UserSessionEntity properties

### DIFF
--- a/apps/api/src/Api/Infrastructure/Entities/UserSessionEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/UserSessionEntity.cs
@@ -1,0 +1,24 @@
+namespace Api.Infrastructure.Entities;
+
+public class UserSessionEntity
+{
+    public string Id { get; set; } = default!;
+    public string TenantId { get; set; } = default!;
+    public string UserId { get; set; } = default!;
+    public string SessionToken { get; set; } = default!;
+    public DateTime CreatedAt { get; set; }
+        = DateTime.UtcNow;
+    public DateTimeOffset? ExpiresAt { get; set; }
+        = null;
+    public DateTimeOffset? LastSeenAt { get; set; }
+        = null;
+    public DateTimeOffset? RevokedAt { get; set; }
+        = null;
+    public string? UserAgent { get; set; }
+        = null;
+    public string? IpAddress { get; set; }
+        = null;
+
+    public TenantEntity Tenant { get; set; } = default!;
+    public UserEntity User { get; set; } = default!;
+}


### PR DESCRIPTION
## Summary
- add the missing UserSessionEntity class to the infrastructure layer
- define ExpiresAt, LastSeenAt, RevokedAt, UserAgent, and IpAddress without stray trailing semicolons

## Testing
- dotnet build -warnaserror *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68daddaee954832095a49361654f1dc5