### PR TITLE
feat: implement admin dashboard for AI request logs (ADM-01) (#27)

### DIFF
--- a/apps/api/src/Api/Infrastructure/Entities/AiRequestLogEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/AiRequestLogEntity.cs
@@ -1,0 +1,20 @@
+namespace Api.Infrastructure.Entities;
+
+public class AiRequestLogEntity
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public string TenantId { get; set; } = default!;
+    public string? UserId { get; set; }
+    public string? GameId { get; set; }
+    public string Endpoint { get; set; } = default!; // "qa", "explain", "setup"
+    public string? Query { get; set; }
+    public string? ResponseSnippet { get; set; }
+    public int LatencyMs { get; set; }
+    public int? TokenCount { get; set; }
+    public double? Confidence { get; set; }
+    public string Status { get; set; } = default!; // "Success", "Error"
+    public string? ErrorMessage { get; set; }
+    public string? IpAddress { get; set; }
+    public string? UserAgent { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -28,6 +28,7 @@ public class MeepleAiDbContext : DbContext
     public DbSet<PdfDocumentEntity> PdfDocuments => Set<PdfDocumentEntity>();
     public DbSet<VectorDocumentEntity> VectorDocuments => Set<VectorDocumentEntity>();
     public DbSet<AuditLogEntity> AuditLogs => Set<AuditLogEntity>();
+    public DbSet<AiRequestLogEntity> AiRequestLogs => Set<AiRequestLogEntity>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -286,6 +287,30 @@ public class MeepleAiDbContext : DbContext
             entity.HasIndex(e => new { e.UserId, e.CreatedAt });
         });
 
+        modelBuilder.Entity<AiRequestLogEntity>(entity =>
+        {
+            entity.ToTable("ai_request_logs");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).HasMaxLength(64);
+            entity.Property(e => e.TenantId).IsRequired().HasMaxLength(64);
+            entity.Property(e => e.UserId).HasMaxLength(64);
+            entity.Property(e => e.GameId).HasMaxLength(64);
+            entity.Property(e => e.Endpoint).IsRequired().HasMaxLength(32);
+            entity.Property(e => e.Query).HasMaxLength(2048);
+            entity.Property(e => e.ResponseSnippet).HasMaxLength(1024);
+            entity.Property(e => e.LatencyMs).IsRequired();
+            entity.Property(e => e.TokenCount);
+            entity.Property(e => e.Confidence);
+            entity.Property(e => e.Status).IsRequired().HasMaxLength(32);
+            entity.Property(e => e.ErrorMessage).HasMaxLength(1024);
+            entity.Property(e => e.IpAddress).HasMaxLength(64);
+            entity.Property(e => e.UserAgent).HasMaxLength(256);
+            entity.Property(e => e.CreatedAt).IsRequired();
+            entity.HasIndex(e => new { e.TenantId, e.CreatedAt });
+            entity.HasIndex(e => new { e.TenantId, e.Endpoint, e.CreatedAt });
+            entity.HasIndex(e => new { e.UserId, e.CreatedAt });
+        });
+
         // AUTH-02: Global query filters for tenant isolation
         // Automatically filter all queries by current tenant using the CurrentTenantId property
         // Note: When CurrentTenantId is null, all data is returned (for migrations, admin operations, etc.)
@@ -299,5 +324,6 @@ public class MeepleAiDbContext : DbContext
         modelBuilder.Entity<PdfDocumentEntity>().HasQueryFilter(e => CurrentTenantId == null || e.TenantId == CurrentTenantId);
         modelBuilder.Entity<VectorDocumentEntity>().HasQueryFilter(e => CurrentTenantId == null || e.TenantId == CurrentTenantId);
         modelBuilder.Entity<AuditLogEntity>().HasQueryFilter(e => CurrentTenantId == null || e.TenantId == CurrentTenantId);
+        modelBuilder.Entity<AiRequestLogEntity>().HasQueryFilter(e => CurrentTenantId == null || e.TenantId == CurrentTenantId);
     }
 }

--- a/apps/api/src/Api/Migrations/20251003231142_ADM01_AddAiRequestLogs.Designer.cs
+++ b/apps/api/src/Api/Migrations/20251003231142_ADM01_AddAiRequestLogs.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Api.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251003231142_ADM01_AddAiRequestLogs")]
+    partial class ADM01_AddAiRequestLogs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Migrations/20251003231142_ADM01_AddAiRequestLogs.cs
+++ b/apps/api/src/Api/Migrations/20251003231142_ADM01_AddAiRequestLogs.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class ADM01_AddAiRequestLogs : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ai_request_logs",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    TenantId = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    UserId = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    GameId = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    Endpoint = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    Query = table.Column<string>(type: "character varying(2048)", maxLength: 2048, nullable: true),
+                    ResponseSnippet = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: true),
+                    LatencyMs = table.Column<int>(type: "integer", nullable: false),
+                    TokenCount = table.Column<int>(type: "integer", nullable: true),
+                    Confidence = table.Column<double>(type: "double precision", nullable: true),
+                    Status = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    ErrorMessage = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: true),
+                    IpAddress = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    UserAgent = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ai_request_logs", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ai_request_logs_TenantId_CreatedAt",
+                table: "ai_request_logs",
+                columns: new[] { "TenantId", "CreatedAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ai_request_logs_TenantId_Endpoint_CreatedAt",
+                table: "ai_request_logs",
+                columns: new[] { "TenantId", "Endpoint", "CreatedAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ai_request_logs_UserId_CreatedAt",
+                table: "ai_request_logs",
+                columns: new[] { "UserId", "CreatedAt" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ai_request_logs");
+        }
+    }
+}

--- a/apps/api/src/Api/Services/AiRequestLogService.cs
+++ b/apps/api/src/Api/Services/AiRequestLogService.cs
@@ -1,0 +1,151 @@
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.Services;
+
+public class AiRequestLogService
+{
+    private readonly MeepleAiDbContext _db;
+    private readonly ILogger<AiRequestLogService> _logger;
+
+    public AiRequestLogService(MeepleAiDbContext db, ILogger<AiRequestLogService> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public async Task LogRequestAsync(
+        string tenantId,
+        string? userId,
+        string? gameId,
+        string endpoint,
+        string? query,
+        string? responseSnippet,
+        int latencyMs,
+        int? tokenCount = null,
+        double? confidence = null,
+        string status = "Success",
+        string? errorMessage = null,
+        string? ipAddress = null,
+        string? userAgent = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var log = new AiRequestLogEntity
+            {
+                TenantId = tenantId,
+                UserId = userId,
+                GameId = gameId,
+                Endpoint = endpoint,
+                Query = query,
+                ResponseSnippet = responseSnippet,
+                LatencyMs = latencyMs,
+                TokenCount = tokenCount,
+                Confidence = confidence,
+                Status = status,
+                ErrorMessage = errorMessage,
+                IpAddress = ipAddress,
+                UserAgent = userAgent,
+                CreatedAt = DateTime.UtcNow
+            };
+
+            _db.AiRequestLogs.Add(log);
+            await _db.SaveChangesAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            // Don't fail the request if logging fails
+            _logger.LogError(ex, "Failed to log AI request for endpoint {Endpoint}", endpoint);
+        }
+    }
+
+    public async Task<List<AiRequestLogEntity>> GetRequestsAsync(
+        string tenantId,
+        int limit = 100,
+        int offset = 0,
+        string? endpoint = null,
+        string? userId = null,
+        DateTime? startDate = null,
+        DateTime? endDate = null,
+        CancellationToken ct = default)
+    {
+        var query = _db.AiRequestLogs
+            .Where(log => log.TenantId == tenantId);
+
+        if (!string.IsNullOrWhiteSpace(endpoint))
+        {
+            query = query.Where(log => log.Endpoint == endpoint);
+        }
+
+        if (!string.IsNullOrWhiteSpace(userId))
+        {
+            query = query.Where(log => log.UserId == userId);
+        }
+
+        if (startDate.HasValue)
+        {
+            query = query.Where(log => log.CreatedAt >= startDate.Value);
+        }
+
+        if (endDate.HasValue)
+        {
+            query = query.Where(log => log.CreatedAt <= endDate.Value);
+        }
+
+        return await query
+            .OrderByDescending(log => log.CreatedAt)
+            .Skip(offset)
+            .Take(limit)
+            .ToListAsync(ct);
+    }
+
+    public async Task<AiRequestStats> GetStatsAsync(
+        string tenantId,
+        DateTime? startDate = null,
+        DateTime? endDate = null,
+        CancellationToken ct = default)
+    {
+        var query = _db.AiRequestLogs
+            .Where(log => log.TenantId == tenantId);
+
+        if (startDate.HasValue)
+        {
+            query = query.Where(log => log.CreatedAt >= startDate.Value);
+        }
+
+        if (endDate.HasValue)
+        {
+            query = query.Where(log => log.CreatedAt <= endDate.Value);
+        }
+
+        var totalRequests = await query.CountAsync(ct);
+        var avgLatency = await query.AverageAsync(log => (double?)log.LatencyMs, ct) ?? 0;
+        var totalTokens = await query.SumAsync(log => log.TokenCount ?? 0, ct);
+        var successCount = await query.CountAsync(log => log.Status == "Success", ct);
+
+        var endpointCounts = await query
+            .GroupBy(log => log.Endpoint)
+            .Select(g => new { Endpoint = g.Key, Count = g.Count() })
+            .ToListAsync(ct);
+
+        return new AiRequestStats
+        {
+            TotalRequests = totalRequests,
+            AvgLatencyMs = avgLatency,
+            TotalTokens = totalTokens,
+            SuccessRate = totalRequests > 0 ? (double)successCount / totalRequests : 0,
+            EndpointCounts = endpointCounts.ToDictionary(x => x.Endpoint, x => x.Count)
+        };
+    }
+}
+
+public record AiRequestStats
+{
+    public int TotalRequests { get; init; }
+    public double AvgLatencyMs { get; init; }
+    public int TotalTokens { get; init; }
+    public double SuccessRate { get; init; }
+    public Dictionary<string, int> EndpointCounts { get; init; } = new();
+}

--- a/apps/web/src/pages/admin.tsx
+++ b/apps/web/src/pages/admin.tsx
@@ -1,0 +1,340 @@
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+type AiRequest = {
+  id: string;
+  tenantId: string;
+  userId: string | null;
+  gameId: string | null;
+  endpoint: string;
+  query: string | null;
+  responseSnippet: string | null;
+  latencyMs: number;
+  tokenCount: number | null;
+  confidence: number | null;
+  status: string;
+  errorMessage: string | null;
+  ipAddress: string | null;
+  userAgent: string | null;
+  createdAt: string;
+};
+
+type Stats = {
+  totalRequests: number;
+  avgLatencyMs: number;
+  totalTokens: number;
+  successRate: number;
+  endpointCounts: Record<string, number>;
+};
+
+export default function AdminDashboard() {
+  const [requests, setRequests] = useState<AiRequest[]>([]);
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [filter, setFilter] = useState<string>("");
+  const [endpointFilter, setEndpointFilter] = useState<string>("all");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchData();
+  }, [endpointFilter]);
+
+  const fetchData = async () => {
+    try {
+      setLoading(true);
+
+      // Fetch requests
+      const endpoint = endpointFilter === "all" ? "" : `&endpoint=${endpointFilter}`;
+      const requestsRes = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/admin/requests?limit=100${endpoint}`, {
+        credentials: "include"
+      });
+
+      if (!requestsRes.ok) {
+        throw new Error("Failed to fetch requests");
+      }
+
+      const requestsData = await requestsRes.json();
+      setRequests(requestsData.requests);
+
+      // Fetch stats
+      const statsRes = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/admin/stats`, {
+        credentials: "include"
+      });
+
+      if (!statsRes.ok) {
+        throw new Error("Failed to fetch stats");
+      }
+
+      const statsData = await statsRes.json();
+      setStats(statsData);
+
+      setLoading(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+      setLoading(false);
+    }
+  };
+
+  const exportToCSV = () => {
+    const headers = ["Timestamp", "Endpoint", "Query", "Latency (ms)", "Tokens", "Status", "User ID", "Game ID"];
+    const rows = requests.map(req => [
+      new Date(req.createdAt).toISOString(),
+      req.endpoint,
+      req.query || "",
+      req.latencyMs.toString(),
+      req.tokenCount?.toString() || "",
+      req.status,
+      req.userId || "",
+      req.gameId || ""
+    ]);
+
+    const csvContent = [headers, ...rows]
+      .map(row => row.map(cell => `"${cell.replace(/"/g, '""')}"`).join(","))
+      .join("\n");
+
+    const blob = new Blob([csvContent], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `ai_requests_${new Date().toISOString()}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const filteredRequests = requests.filter(
+    (req) =>
+      req.query?.toLowerCase().includes(filter.toLowerCase()) ||
+      req.endpoint.toLowerCase().includes(filter.toLowerCase()) ||
+      req.userId?.toLowerCase().includes(filter.toLowerCase()) ||
+      req.gameId?.toLowerCase().includes(filter.toLowerCase())
+  );
+
+  const getStatusColor = (status: string) => {
+    return status === "Success" ? "#0f9d58" : "#d93025";
+  };
+
+  const getEndpointColor = (endpoint: string) => {
+    switch (endpoint) {
+      case "qa":
+        return "#1a73e8";
+      case "explain":
+        return "#f9ab00";
+      case "setup":
+        return "#a142f4";
+      default:
+        return "#5f6368";
+    }
+  };
+
+  if (loading) {
+    return (
+      <main style={{ padding: 24, fontFamily: "sans-serif", maxWidth: 1400, margin: "0 auto" }}>
+        <h1>Loading...</h1>
+      </main>
+    );
+  }
+
+  if (error) {
+    return (
+      <main style={{ padding: 24, fontFamily: "sans-serif", maxWidth: 1400, margin: "0 auto" }}>
+        <h1>Error</h1>
+        <p style={{ color: "#d93025" }}>{error}</p>
+        <Link href="/" style={{ color: "#1a73e8" }}>Back to Home</Link>
+      </main>
+    );
+  }
+
+  return (
+    <main style={{ padding: 24, fontFamily: "sans-serif", maxWidth: 1400, margin: "0 auto" }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 24 }}>
+        <div>
+          <h1 style={{ margin: 0 }}>Admin Dashboard</h1>
+          <p style={{ margin: "8px 0 0 0", color: "#5f6368" }}>
+            Monitor AI requests, latency, and token usage
+          </p>
+        </div>
+        <div style={{ display: "flex", gap: 12 }}>
+          <button
+            onClick={exportToCSV}
+            style={{
+              padding: "8px 16px",
+              background: "#0f9d58",
+              color: "white",
+              border: "none",
+              borderRadius: 4,
+              cursor: "pointer"
+            }}
+          >
+            Export CSV
+          </button>
+          <Link
+            href="/"
+            style={{
+              padding: "8px 16px",
+              background: "#1a73e8",
+              color: "white",
+              textDecoration: "none",
+              borderRadius: 4,
+              display: "inline-block"
+            }}
+          >
+            Back to Home
+          </Link>
+        </div>
+      </div>
+
+      {/* Statistics Cards */}
+      {stats && (
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 16, marginBottom: 24 }}>
+          <div style={{ padding: 24, border: "1px solid #dadce0", borderRadius: 8, background: "white" }}>
+            <div style={{ fontSize: 12, color: "#5f6368", marginBottom: 8 }}>Total Requests</div>
+            <div style={{ fontSize: 32, fontWeight: 600 }}>{stats.totalRequests}</div>
+          </div>
+          <div style={{ padding: 24, border: "1px solid #dadce0", borderRadius: 8, background: "white" }}>
+            <div style={{ fontSize: 12, color: "#5f6368", marginBottom: 8 }}>Avg Latency</div>
+            <div style={{ fontSize: 32, fontWeight: 600 }}>{Math.round(stats.avgLatencyMs)}ms</div>
+          </div>
+          <div style={{ padding: 24, border: "1px solid #dadce0", borderRadius: 8, background: "white" }}>
+            <div style={{ fontSize: 12, color: "#5f6368", marginBottom: 8 }}>Total Tokens</div>
+            <div style={{ fontSize: 32, fontWeight: 600 }}>{stats.totalTokens}</div>
+          </div>
+          <div style={{ padding: 24, border: "1px solid #dadce0", borderRadius: 8, background: "white" }}>
+            <div style={{ fontSize: 12, color: "#5f6368", marginBottom: 8 }}>Success Rate</div>
+            <div style={{ fontSize: 32, fontWeight: 600 }}>{(stats.successRate * 100).toFixed(1)}%</div>
+          </div>
+        </div>
+      )}
+
+      {/* Endpoint Breakdown */}
+      {stats && (
+        <div style={{ padding: 24, border: "1px solid #dadce0", borderRadius: 8, background: "white", marginBottom: 24 }}>
+          <h3 style={{ marginTop: 0, marginBottom: 16 }}>Requests by Endpoint</h3>
+          <div style={{ display: "flex", gap: 24 }}>
+            {Object.entries(stats.endpointCounts).map(([endpoint, count]) => (
+              <div key={endpoint} style={{ flex: 1 }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+                  <div
+                    style={{
+                      width: 12,
+                      height: 12,
+                      borderRadius: "50%",
+                      background: getEndpointColor(endpoint)
+                    }}
+                  />
+                  <div style={{ fontSize: 14, fontWeight: 600 }}>{endpoint}</div>
+                </div>
+                <div style={{ fontSize: 24, fontWeight: 600, color: getEndpointColor(endpoint) }}>{count}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Filters */}
+      <div style={{ display: "flex", gap: 12, marginBottom: 24 }}>
+        <input
+          type="text"
+          placeholder="Filter by query, endpoint, user ID, or game ID..."
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          style={{
+            flex: 1,
+            padding: 12,
+            fontSize: 14,
+            border: "1px solid #dadce0",
+            borderRadius: 4
+          }}
+        />
+        <select
+          value={endpointFilter}
+          onChange={(e) => setEndpointFilter(e.target.value)}
+          style={{
+            padding: 12,
+            fontSize: 14,
+            border: "1px solid #dadce0",
+            borderRadius: 4,
+            background: "white"
+          }}
+        >
+          <option value="all">All Endpoints</option>
+          <option value="qa">QA</option>
+          <option value="explain">Explain</option>
+          <option value="setup">Setup</option>
+        </select>
+      </div>
+
+      {/* Requests Table */}
+      <div style={{ border: "1px solid #dadce0", borderRadius: 8, overflow: "hidden" }}>
+        <div
+          style={{
+            padding: 16,
+            background: "#f8f9fa",
+            borderBottom: "1px solid #dadce0",
+            display: "grid",
+            gridTemplateColumns: "140px 80px 100px 80px 80px 1fr 100px",
+            gap: 16,
+            fontSize: 12,
+            fontWeight: 600,
+            color: "#5f6368",
+            textTransform: "uppercase"
+          }}
+        >
+          <div>Timestamp</div>
+          <div>Endpoint</div>
+          <div>Game ID</div>
+          <div>Latency</div>
+          <div>Tokens</div>
+          <div>Query</div>
+          <div>Status</div>
+        </div>
+
+        {filteredRequests.length === 0 ? (
+          <div style={{ padding: 48, textAlign: "center", color: "#5f6368" }}>
+            <p>No AI requests found.</p>
+          </div>
+        ) : (
+          filteredRequests.map((req) => (
+            <div
+              key={req.id}
+              style={{
+                padding: 16,
+                borderBottom: "1px solid #f0f0f0",
+                display: "grid",
+                gridTemplateColumns: "140px 80px 100px 80px 80px 1fr 100px",
+                gap: 16,
+                fontSize: 13,
+                alignItems: "start"
+              }}
+            >
+              <div style={{ color: "#5f6368", fontSize: 11, fontFamily: "monospace" }}>
+                {new Date(req.createdAt).toLocaleString()}
+              </div>
+              <div
+                style={{
+                  color: getEndpointColor(req.endpoint),
+                  fontWeight: 600,
+                  fontSize: 12
+                }}
+              >
+                {req.endpoint}
+              </div>
+              <div style={{ fontSize: 11, fontFamily: "monospace", color: "#5f6368" }}>
+                {req.gameId?.substring(0, 8) || "-"}
+              </div>
+              <div style={{ fontSize: 12, fontFamily: "monospace" }}>{req.latencyMs}ms</div>
+              <div style={{ fontSize: 12, fontFamily: "monospace", color: "#5f6368" }}>
+                {req.tokenCount || "-"}
+              </div>
+              <div style={{ fontSize: 12, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {req.query || "-"}
+              </div>
+              <div style={{ color: getStatusColor(req.status), fontWeight: 600, fontSize: 12 }}>
+                {req.status}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

Implements admin dashboard for monitoring AI requests, latency, and token usage as specified in ADM-01.

**Backend:**
- Created `AiRequestLogEntity` and `AiRequestLogService` to track AI requests
- Added `/admin/requests` and `/admin/stats` endpoints for data retrieval
- Integrated logging in all AI endpoints (qa, explain, setup)
- Database migration for `ai_request_logs` table

**Frontend:**
- Admin dashboard page at `/admin` with request table and statistics
- Real-time metrics: total requests, avg latency, total tokens, success rate
- Endpoint breakdown visualization
- CSV export functionality
- Advanced filtering by endpoint, user, game

**Security:**
- Admin-only access with role-based authorization
- Tenant isolation enforced
- Error tracking and logging

## Test plan
- [x] Backend compiles successfully
- [x] Migration created and applied
- [x] Frontend builds without errors
- [ ] Manual testing: verify admin dashboard displays correctly
- [ ] Manual testing: verify CSV export works
- [ ] Manual testing: verify statistics are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)