### PR TITLE
feat: implement AI-04 - Q&A with snippets and 'Not specified' fallback (#23)

### DIFF
--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -54,6 +54,7 @@ builder.Services.AddSingleton<IBackgroundTaskService, BackgroundTaskService>();
 // AI-01: Vector search services
 builder.Services.AddSingleton<IQdrantService, QdrantService>();
 builder.Services.AddScoped<IEmbeddingService, EmbeddingService>();
+builder.Services.AddScoped<ILlmService, LlmService>();
 builder.Services.AddScoped<TextChunkingService>();
 
 builder.Services.AddScoped<RuleSpecService>();

--- a/apps/api/src/Api/Services/ILlmService.cs
+++ b/apps/api/src/Api/Services/ILlmService.cs
@@ -1,0 +1,31 @@
+namespace Api.Services;
+
+/// <summary>
+/// Interface for LLM chat completion services
+/// </summary>
+public interface ILlmService
+{
+    /// <summary>
+    /// Generate a chat completion response
+    /// </summary>
+    Task<LlmCompletionResult> GenerateCompletionAsync(
+        string systemPrompt,
+        string userPrompt,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Result of LLM completion
+/// </summary>
+public record LlmCompletionResult
+{
+    public bool Success { get; init; }
+    public string? ErrorMessage { get; init; }
+    public string Response { get; init; } = string.Empty;
+
+    public static LlmCompletionResult CreateSuccess(string response) =>
+        new() { Success = true, Response = response };
+
+    public static LlmCompletionResult CreateFailure(string error) =>
+        new() { Success = false, ErrorMessage = error };
+}

--- a/apps/api/src/Api/Services/LlmService.cs
+++ b/apps/api/src/Api/Services/LlmService.cs
@@ -1,0 +1,146 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Api.Services;
+
+/// <summary>
+/// Service for LLM chat completions via OpenRouter API
+/// </summary>
+public class LlmService : ILlmService
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<LlmService> _logger;
+    private readonly string _apiKey;
+    private const string ChatModel = "anthropic/claude-3.5-sonnet";
+
+    public LlmService(IHttpClientFactory httpClientFactory, IConfiguration config, ILogger<LlmService> logger)
+    {
+        _httpClient = httpClientFactory.CreateClient("OpenRouter");
+        _logger = logger;
+        _apiKey = config["OPENROUTER_API_KEY"] ?? throw new InvalidOperationException("OPENROUTER_API_KEY not configured");
+
+        // Configure HttpClient
+        _httpClient.BaseAddress = new Uri("https://openrouter.ai/api/v1/");
+        _httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {_apiKey}");
+        _httpClient.DefaultRequestHeaders.Add("HTTP-Referer", "https://meepleai.app");
+        _httpClient.Timeout = TimeSpan.FromSeconds(60);
+    }
+
+    /// <summary>
+    /// Generate a chat completion response
+    /// </summary>
+    public async Task<LlmCompletionResult> GenerateCompletionAsync(
+        string systemPrompt,
+        string userPrompt,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(userPrompt))
+        {
+            return LlmCompletionResult.CreateFailure("No user prompt provided");
+        }
+
+        try
+        {
+            var messages = new List<object>();
+
+            if (!string.IsNullOrWhiteSpace(systemPrompt))
+            {
+                messages.Add(new { role = "system", content = systemPrompt });
+            }
+
+            messages.Add(new { role = "user", content = userPrompt });
+
+            var request = new
+            {
+                model = ChatModel,
+                messages = messages,
+                temperature = 0.3, // Lower temperature for more deterministic, factual responses
+                max_tokens = 500
+            };
+
+            var json = JsonSerializer.Serialize(request);
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+            _logger.LogInformation("Generating chat completion using {Model}", ChatModel);
+
+            var response = await _httpClient.PostAsync("chat/completions", content, ct);
+            var responseBody = await response.Content.ReadAsStringAsync(ct);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogError("OpenRouter chat API error: {Status} - {Body}", response.StatusCode, responseBody);
+                return LlmCompletionResult.CreateFailure($"API error: {response.StatusCode}");
+            }
+
+            var chatResponse = JsonSerializer.Deserialize<OpenRouterChatResponse>(responseBody);
+
+            if (chatResponse?.Choices == null || chatResponse.Choices.Count == 0)
+            {
+                return LlmCompletionResult.CreateFailure("No response returned from API");
+            }
+
+            var assistantMessage = chatResponse.Choices[0].Message?.Content ?? string.Empty;
+
+            _logger.LogInformation("Successfully generated chat completion");
+
+            return LlmCompletionResult.CreateSuccess(assistantMessage);
+        }
+        catch (TaskCanceledException ex)
+        {
+            _logger.LogError(ex, "Chat completion timed out");
+            return LlmCompletionResult.CreateFailure("Request timed out");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to generate chat completion");
+            return LlmCompletionResult.CreateFailure($"Error: {ex.Message}");
+        }
+    }
+}
+
+// OpenRouter API response models for chat completion
+internal record OpenRouterChatResponse
+{
+    [JsonPropertyName("id")]
+    public string Id { get; init; } = string.Empty;
+
+    [JsonPropertyName("choices")]
+    public List<ChatChoice> Choices { get; init; } = new();
+
+    [JsonPropertyName("model")]
+    public string Model { get; init; } = string.Empty;
+
+    [JsonPropertyName("usage")]
+    public ChatUsage? Usage { get; init; }
+}
+
+internal record ChatChoice
+{
+    [JsonPropertyName("message")]
+    public ChatMessage? Message { get; init; }
+
+    [JsonPropertyName("finish_reason")]
+    public string FinishReason { get; init; } = string.Empty;
+}
+
+internal record ChatMessage
+{
+    [JsonPropertyName("role")]
+    public string Role { get; init; } = string.Empty;
+
+    [JsonPropertyName("content")]
+    public string Content { get; init; } = string.Empty;
+}
+
+internal record ChatUsage
+{
+    [JsonPropertyName("prompt_tokens")]
+    public int PromptTokens { get; init; }
+
+    [JsonPropertyName("completion_tokens")]
+    public int CompletionTokens { get; init; }
+
+    [JsonPropertyName("total_tokens")]
+    public int TotalTokens { get; init; }
+}

--- a/apps/api/tests/Api.Tests/QaEndpointTests.cs
+++ b/apps/api/tests/Api.Tests/QaEndpointTests.cs
@@ -61,8 +61,15 @@ public class QaEndpointTests
             .ReturnsAsync(searchResult);
 
         var ragLoggerMock = Mock.Of<ILogger<RagService>>();
+        var llmServiceMock = new Mock<ILlmService>();
 
-        var ragService = new RagService(dbContext, embeddingServiceMock.Object, qdrantServiceMock.Object, ragLoggerMock);
+        // Configure LLM mock to return successful completion
+        var llmResult = LlmCompletionResult.CreateSuccess("Two players.");
+        llmServiceMock
+            .Setup(l => l.GenerateCompletionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(llmResult);
+
+        var ragService = new RagService(dbContext, embeddingServiceMock.Object, qdrantServiceMock.Object, llmServiceMock.Object, ragLoggerMock);
 
         var tenantId = "tenant-test";
         var gameId = "demo-chess";


### PR DESCRIPTION
## Summary
Implements AI-04: Q&A system with snippets and anti-hallucination "Not specified" fallback.

## Changes
- ✅ Created LLM service for chat completions using OpenRouter API (Claude 3.5 Sonnet)
- ✅ Updated RagService to use LLM for answer generation with anti-hallucination prompts
- ✅ System generates answers based on retrieved context with strict instructions
- ✅ Returns "Not specified" when answer is not in context or no vector results found
- ✅ Maintains snippet references for transparency

## Technical Details
- Added `ILlmService` interface and `LlmService` implementation
- Uses Claude 3.5 Sonnet via OpenRouter with low temperature (0.3)
- System prompt enforces context-only responses to prevent hallucination
- Updated all unit tests to mock LLM service (265 tests passed)
- Added specific test case for anti-hallucination behavior

## Acceptance Criteria
✅ Answers include snippets from source material  
✅ Returns "Not specified" when answer not in context  
✅ No hallucination - LLM instructed to only use provided context  
✅ E2E test verifies no hallucination without snippets  

## Test Plan
- [x] Unit tests pass (265/265 excluding integration tests)
- [x] New test added for "Not specified" fallback behavior
- [x] Existing QA tests updated for LLM-based responses
- [ ] Manual testing with running services

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)