### PR TITLE
Refactor web app to remove tenant-specific UI and payloads

### DIFF
--- a/apps/web/src/pages/__tests__/upload.test.tsx
+++ b/apps/web/src/pages/__tests__/upload.test.tsx
@@ -25,7 +25,6 @@ describe('UploadPage', () => {
     const authResponse = {
       user: {
         id: 'user-1',
-        tenantId: 'tenant-1',
         email: 'user@example.com',
         role: 'Admin',
         displayName: 'User'
@@ -78,7 +77,6 @@ describe('UploadPage', () => {
     const authResponse = {
       user: {
         id: 'user-2',
-        tenantId: 'tenant-2',
         email: 'user2@example.com',
         role: 'Admin',
         displayName: 'User Two'

--- a/apps/web/src/pages/admin.tsx
+++ b/apps/web/src/pages/admin.tsx
@@ -3,7 +3,6 @@ import Link from "next/link";
 
 type AiRequest = {
   id: string;
-  tenantId: string;
   userId: string | null;
   gameId: string | null;
   endpoint: string;

--- a/apps/web/src/pages/chat.tsx
+++ b/apps/web/src/pages/chat.tsx
@@ -4,7 +4,6 @@ import { api } from "../lib/api";
 
 type AuthUser = {
   id: string;
-  tenantId: string;
   email: string;
   displayName?: string | null;
   role: string;
@@ -86,7 +85,6 @@ export default function ChatPage() {
 
     try {
       const res = await api.post<QAResponse>("/agents/qa", {
-        tenantId: authUser.tenantId,
         gameId: selectedGame,
         query: inputValue
       });

--- a/apps/web/src/pages/editor.tsx
+++ b/apps/web/src/pages/editor.tsx
@@ -20,7 +20,6 @@ type RuleSpec = {
 
 type AuthUser = {
   id: string;
-  tenantId: string;
   email: string;
   displayName?: string | null;
   role: string;

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -4,7 +4,6 @@ import { api } from "../lib/api";
 
 type AuthUser = {
   id: string;
-  tenantId: string;
   email: string;
   displayName?: string | null;
   role: string;
@@ -15,23 +14,18 @@ type AuthResponse = {
   expiresAt: string;
 };
 
-const DEFAULT_TENANT = process.env.NEXT_PUBLIC_TENANT_ID || "dev";
-
 export default function Home() {
   const [answer, setAnswer] = useState<string>("");
   const [authUser, setAuthUser] = useState<AuthUser | null>(null);
   const [statusMessage, setStatusMessage] = useState<string>("");
   const [errorMessage, setErrorMessage] = useState<string>("");
   const [registerForm, setRegisterForm] = useState({
-    tenantId: DEFAULT_TENANT,
-    tenantName: "",
     email: "",
     password: "",
     displayName: "",
     role: "User"
   });
   const [loginForm, setLoginForm] = useState({
-    tenantId: DEFAULT_TENANT,
     email: "",
     password: ""
   });
@@ -69,7 +63,6 @@ export default function Home() {
     setIsLoading(true);
     try {
       const res = await api.post<{ answer: string }>("/agents/qa", {
-        tenantId: authUser.tenantId,
         gameId: "demo-chess",
         query: "How many players?"
       });
@@ -88,8 +81,6 @@ export default function Home() {
     setErrorMessage("");
     try {
       const payload = {
-        tenantId: registerForm.tenantId,
-        tenantName: registerForm.tenantName || undefined,
         email: registerForm.email,
         password: registerForm.password,
         displayName: registerForm.displayName || undefined,
@@ -99,8 +90,6 @@ export default function Home() {
       setAuthUser(res.user);
       setStatusMessage("Registrazione completata. Sei connesso!");
       setRegisterForm({
-        tenantId: registerForm.tenantId,
-        tenantName: "",
         email: "",
         password: "",
         displayName: "",
@@ -117,13 +106,12 @@ export default function Home() {
     setErrorMessage("");
     try {
       const res = await api.post<AuthResponse>("/auth/login", {
-        tenantId: loginForm.tenantId,
         email: loginForm.email,
         password: loginForm.password
       });
       setAuthUser(res.user);
       setStatusMessage("Accesso eseguito.");
-      setLoginForm({ tenantId: loginForm.tenantId, email: "", password: "" });
+      setLoginForm({ email: "", password: "" });
     } catch (err: any) {
       console.error(err);
       setErrorMessage(err?.message || "Accesso non riuscito.");
@@ -211,23 +199,6 @@ export default function Home() {
         <form onSubmit={handleRegister} style={{ flex: "1 1 320px", border: "1px solid #ccc", padding: 16, borderRadius: 8 }}>
           <h2>Registrazione</h2>
           <label style={{ display: "block", marginBottom: 8 }}>
-            Tenant ID
-            <input
-              value={registerForm.tenantId}
-              onChange={(e) => setRegisterForm({ ...registerForm, tenantId: e.target.value })}
-              style={{ width: "100%" }}
-              required
-            />
-          </label>
-          <label style={{ display: "block", marginBottom: 8 }}>
-            Nome Tenant
-            <input
-              value={registerForm.tenantName}
-              onChange={(e) => setRegisterForm({ ...registerForm, tenantName: e.target.value })}
-              style={{ width: "100%" }}
-            />
-          </label>
-          <label style={{ display: "block", marginBottom: 8 }}>
             Email
             <input
               type="email"
@@ -274,15 +245,6 @@ export default function Home() {
         <form onSubmit={handleLogin} style={{ flex: "1 1 320px", border: "1px solid #ccc", padding: 16, borderRadius: 8 }}>
           <h2>Accesso</h2>
           <label style={{ display: "block", marginBottom: 8 }}>
-            Tenant ID
-            <input
-              value={loginForm.tenantId}
-              onChange={(e) => setLoginForm({ ...loginForm, tenantId: e.target.value })}
-              style={{ width: "100%" }}
-              required
-            />
-          </label>
-          <label style={{ display: "block", marginBottom: 8 }}>
             Email
             <input
               type="email"
@@ -315,9 +277,6 @@ export default function Home() {
           <div style={{ border: "1px solid #ccc", padding: 16, borderRadius: 8 }}>
             <p>
               <strong>Email:</strong> {authUser.email}
-            </p>
-            <p>
-              <strong>Tenant:</strong> {authUser.tenantId}
             </p>
             <p>
               <strong>Ruolo:</strong> {authUser.role}

--- a/apps/web/src/pages/logs.tsx
+++ b/apps/web/src/pages/logs.tsx
@@ -7,7 +7,6 @@ type LogEntry = {
   message: string;
   requestId?: string;
   userId?: string;
-  tenantId?: string;
 };
 
 export default function LogsPage() {
@@ -29,8 +28,7 @@ export default function LogsPage() {
         level: "INFO",
         message: "User logged in successfully",
         requestId: "req-002",
-        userId: "user-123",
-        tenantId: "dev"
+        userId: "user-123"
       }
     ];
     setLogs(sampleLogs);
@@ -103,7 +101,7 @@ export default function LogsPage() {
             background: "#f8f9fa",
             borderBottom: "1px solid #dadce0",
             display: "grid",
-            gridTemplateColumns: "180px 80px 100px 100px 100px 1fr",
+            gridTemplateColumns: "180px 80px 120px 120px 1fr",
             gap: 16,
             fontSize: 12,
             fontWeight: 600,
@@ -115,7 +113,6 @@ export default function LogsPage() {
           <div>Level</div>
           <div>Request ID</div>
           <div>User ID</div>
-          <div>Tenant ID</div>
           <div>Message</div>
         </div>
 
@@ -135,7 +132,7 @@ export default function LogsPage() {
                 padding: 16,
                 borderBottom: index < filteredLogs.length - 1 ? "1px solid #f0f0f0" : "none",
                 display: "grid",
-                gridTemplateColumns: "180px 80px 100px 100px 100px 1fr",
+                gridTemplateColumns: "180px 80px 120px 120px 1fr",
                 gap: 16,
                 fontSize: 13,
                 alignItems: "start"
@@ -151,9 +148,6 @@ export default function LogsPage() {
               <div style={{ fontSize: 11, fontFamily: "monospace", color: "#5f6368" }}>
                 {log.userId || "-"}
               </div>
-              <div style={{ fontSize: 11, fontFamily: "monospace", color: "#5f6368" }}>
-                {log.tenantId || "-"}
-              </div>
               <div>{log.message}</div>
             </div>
           ))
@@ -168,7 +162,7 @@ export default function LogsPage() {
             <code>TraceIdentifier</code>)
           </li>
           <li>All logs for a request include the same correlation ID for tracing</li>
-          <li>Structured logging with Serilog enriches logs with user, tenant, and request metadata</li>
+          <li>Structured logging with Serilog enriches logs with user and request metadata</li>
           <li>Filter logs by correlation ID to trace a specific request through the system</li>
         </ul>
         <p style={{ marginBottom: 0, marginTop: 12, fontSize: 13, color: "#5f6368" }}>

--- a/apps/web/src/pages/n8n.tsx
+++ b/apps/web/src/pages/n8n.tsx
@@ -3,7 +3,6 @@ import Link from "next/link";
 
 type N8nConfig = {
   id: string;
-  tenantId: string;
   name: string;
   baseUrl: string;
   webhookUrl: string | null;

--- a/apps/web/src/pages/upload.tsx
+++ b/apps/web/src/pages/upload.tsx
@@ -33,7 +33,6 @@ interface GameSummary {
 
 interface AuthUser {
   id: string;
-  tenantId: string;
   email: string;
   displayName?: string | null;
   role: string;
@@ -327,7 +326,6 @@ export default function UploadPage() {
 
     try {
       const created = await api.post<GameSummary>('/games', {
-        tenantId: authUser.tenantId,
         name: trimmedName
       });
 

--- a/apps/web/src/pages/versions.tsx
+++ b/apps/web/src/pages/versions.tsx
@@ -5,7 +5,6 @@ import { api } from "../lib/api";
 
 type AuthUser = {
   id: string;
-  tenantId: string;
   email: string;
   displayName?: string | null;
   role: string;


### PR DESCRIPTION
## Summary
- remove tenant fields from authentication forms and session display on the home page
- update client API calls and supporting pages to rely on authenticated user context instead of tenant identifiers
- simplify observability logs and admin types to reflect tenantless payloads and refresh supporting tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e21ed8ec188320a508c63aaf1d1035