### PR TITLE
fix: remove tenant references from audit log

### DIFF
--- a/apps/api/src/Api/Services/AuditService.cs
+++ b/apps/api/src/Api/Services/AuditService.cs
@@ -60,7 +60,7 @@ public class AuditService
         string? userAgent = null,
         CancellationToken ct = default)
     {
-        var details = $"User from tenant {userTenantId} attempted to access {resource} in tenant {requestedTenantId}";
+        var details = $"User in scope {userScope} attempted to access {resource} requiring scope {requiredScope}";
 
         await LogAsync(
             userId,
@@ -68,7 +68,7 @@ public class AuditService
             resource,
             resourceId,
             "Denied",
-            $"User in scope {userScope} attempted to access {resource} requiring scope {requiredScope}",
+            details,
             ipAddress,
             userAgent,
             ct);


### PR DESCRIPTION
## Summary
- remove the leftover tenant-specific messaging from the audit access denied helper so logs align with the global dataset

## Testing
- `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj -c Release --filter AuthServiceTests` *(fails: dotnet CLI not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e244acb3948320a6ebfbeac2801e21