### PR TITLE
Add injectable PdfStorageService dependencies and expand background-processing tests

### DIFF
--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -52,7 +52,7 @@ builder.Services.AddSingleton<IBackgroundTaskService, BackgroundTaskService>();
 builder.Services.AddSingleton<IQdrantService, QdrantService>();
 builder.Services.AddScoped<IEmbeddingService, EmbeddingService>();
 builder.Services.AddScoped<ILlmService, LlmService>();
-builder.Services.AddScoped<TextChunkingService>();
+builder.Services.AddScoped<ITextChunkingService, TextChunkingService>();
 
 // AI-05: AI response caching
 builder.Services.AddSingleton<IAiResponseCacheService, AiResponseCacheService>();
@@ -106,7 +106,7 @@ using (var scope = app.Services.CreateScope())
         db.Database.Migrate();
 
         // AI-01: Initialize Qdrant collection
-        var qdrant = scope.ServiceProvider.GetRequiredService<QdrantService>();
+        var qdrant = scope.ServiceProvider.GetRequiredService<IQdrantService>();
         await qdrant.EnsureCollectionExistsAsync();
     }
 }

--- a/apps/api/src/Api/Services/ITextChunkingService.cs
+++ b/apps/api/src/Api/Services/ITextChunkingService.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace Api.Services;
+
+public interface ITextChunkingService
+{
+    List<TextChunk> ChunkText(string text, int chunkSize = 512, int overlap = 50);
+
+    List<DocumentChunkInput> PrepareForEmbedding(string text, int chunkSize = 512, int overlap = 50);
+}

--- a/apps/api/src/Api/Services/PdfTableExtractionService.cs
+++ b/apps/api/src/Api/Services/PdfTableExtractionService.cs
@@ -21,7 +21,7 @@ public class PdfTableExtractionService
     /// <summary>
     /// Extracts tables and structured content from a PDF file
     /// </summary>
-    public async Task<PdfStructuredExtractionResult> ExtractStructuredContentAsync(
+    public virtual async Task<PdfStructuredExtractionResult> ExtractStructuredContentAsync(
         string filePath,
         CancellationToken ct = default)
     {

--- a/apps/api/src/Api/Services/PdfTextExtractionService.cs
+++ b/apps/api/src/Api/Services/PdfTextExtractionService.cs
@@ -23,7 +23,7 @@ public class PdfTextExtractionService
     /// <param name="filePath">Path to the PDF file</param>
     /// <param name="ct">Cancellation token</param>
     /// <returns>Extraction result containing normalized text and metadata</returns>
-    public async Task<PdfTextExtractionResult> ExtractTextAsync(string filePath, CancellationToken ct = default)
+    public virtual async Task<PdfTextExtractionResult> ExtractTextAsync(string filePath, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(filePath))
         {

--- a/apps/api/src/Api/Services/TextChunkingService.cs
+++ b/apps/api/src/Api/Services/TextChunkingService.cs
@@ -3,7 +3,7 @@ namespace Api.Services;
 /// <summary>
 /// Service for chunking text documents into smaller segments for embedding
 /// </summary>
-public class TextChunkingService
+public class TextChunkingService : ITextChunkingService
 {
     private readonly ILogger<TextChunkingService> _logger;
     private const int DefaultChunkSize = 512; // characters


### PR DESCRIPTION
## Summary
- introduce ITextChunkingService and update PdfStorageService to accept optional chunking, embedding, and Qdrant overrides while falling back to scoped services
- make PDF extraction services overridable and adjust Program registrations to resolve abstractions for background processing
- rework PdfStorageService tests to use scoped service collections with fakes and execute captured background tasks to verify processing and indexing behaviour

## Testing
- `dotnet test tests/Api.Tests/Api.Tests.csproj` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e25471af508320a9eb38a449eadc21