### PR TITLE
docs: update roadmap for rulespec lifecycle status

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Accogliamo contributi dalla community! Prima di iniziare:
 - ✅ RAG (Retrieval-Augmented Generation) con Qdrant
 - ✅ PDF extraction service (Docnet + tabelle)
 - ✅ Seed demo data per testing
+- ✅ Storico versioni, diff e ripristino delle RuleSpec disponibili via API `GET /rulespecs/{id}/versions` e interfaccia `/versions`
 
 #### Frontend (Next.js)
 - ✅ Interfaccia web React/TypeScript
@@ -181,9 +182,6 @@ Accogliamo contributi dalla community! Prima di iniziare:
   - Follow-up questions intelligenti
 
 - 📋 **Gestione avanzata rule specs**
-  - Versioning documenti
-  - Diff tra versioni
-  - Publishing workflow
   - Retention policy per vecchie versioni
 
 #### UX & Frontend


### PR DESCRIPTION
## Summary
- note that RuleSpec version history, diff, and restore are already available via the API and `/versions` page
- remove the versioning, diff, and publishing tasks from the planned roadmap since they are complete

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e25714a8088320860ad836fb511a3a