### PR TITLE
docs: mark pdf upload wizard complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Accogliamo contributi dalla community! Prima di iniziare:
 - ✅ API client con gestione errori
 - ✅ Health check endpoints
 - ✅ Integrazione con backend API
+- ✅ Gestione upload PDF con wizard multi-step con tracking avanzato dei progressi, connesso agli endpoint backend `/ingest/pdf` e `/games/{id}/pdfs`
 
 #### Automazione
 - ✅ n8n workflow engine setup
@@ -189,7 +190,6 @@ Accogliamo contributi dalla community! Prima di iniziare:
 #### UX & Frontend
 - 📋 UI/UX completo per chat interfaccia
 - 📋 Dashboard amministrazione contenuti
-- 📋 Gestione upload PDF con progress tracking
 - 📋 Visualizzazione source documents per risposte
 
 #### Integrazioni


### PR DESCRIPTION
## Summary
- move the PDF upload progress tracking item from planned to completed
- document the existing multi-step wizard and reference the supporting ingestion endpoints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2577a3a7883209340fafa64a55d12