### PR TITLE
test: add page coverage and e2e auth journeys

### DIFF
--- a/apps/web/e2e/authenticated.spec.ts
+++ b/apps/web/e2e/authenticated.spec.ts
@@ -1,0 +1,217 @@
+import { test, expect, Page, Route } from '@playwright/test';
+import { Buffer } from 'buffer';
+
+const apiBase = 'http://localhost:8080';
+
+async function setupAuthRoutes(page: Page) {
+  let authenticated = false;
+  const userResponse = {
+    user: {
+      id: 'admin-1',
+      email: 'admin@example.com',
+      displayName: 'Admin Example',
+      role: 'Admin'
+    },
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString()
+  };
+
+  await page.route(`${apiBase}/auth/me`, async (route) => {
+    if (authenticated) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(userResponse)
+      });
+    } else {
+      await route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'Unauthorized' })
+      });
+    }
+  });
+
+  const handleAuthSuccess = async (route: Route) => {
+    authenticated = true;
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(userResponse)
+    });
+  };
+
+  await page.route(`${apiBase}/auth/login`, handleAuthSuccess);
+  await page.route(`${apiBase}/auth/register`, handleAuthSuccess);
+  await page.route(`${apiBase}/auth/logout`, async (route) => {
+    authenticated = false;
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ success: true })
+    });
+  });
+
+  return {
+    authenticate() {
+      authenticated = true;
+    },
+    reset() {
+      authenticated = false;
+    },
+    userResponse
+  };
+}
+
+test.describe('Authenticated journeys', () => {
+  test('allows a user to log in from the home page', async ({ page }) => {
+    await setupAuthRoutes(page);
+
+    await page.goto('/');
+
+    const loginForm = page
+      .locator('form')
+      .filter({ has: page.getByRole('heading', { name: 'Accesso' }) });
+
+    await loginForm.getByLabel('Email').fill('admin@example.com');
+    await loginForm.getByLabel('Password').fill('supersecure');
+    await loginForm.getByRole('button', { name: 'Entra' }).click();
+
+    await expect(page.getByText('Accesso eseguito.')).toBeVisible();
+    await expect(page.getByText(/Email:\s*admin@example.com/)).toBeVisible();
+    await expect(page.getByText(/Ruolo:\s*Admin/)).toBeVisible();
+
+  });
+
+  test('supports an authenticated chat exchange', async ({ page }) => {
+    const auth = await setupAuthRoutes(page);
+    auth.authenticate();
+
+    await page.route(`${apiBase}/agents/qa`, async (route) => {
+      const requestBody = route.request().postDataJSON() as { query: string };
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          answer: `Risposta per: ${requestBody.query}`,
+          sources: [
+            { title: 'Manuale Demo', snippet: 'Capitolo introduttivo', page: 2 }
+          ]
+        })
+      });
+    });
+
+    await page.goto('/chat');
+
+    await expect(page.getByRole('heading', { name: 'MeepleAI Chat' })).toBeVisible();
+
+    const input = page.getByPlaceholder('Fai una domanda sul gioco...');
+    await input.fill('Qual è la durata media?');
+    await page.getByRole('button', { name: 'Invia' }).click();
+
+    await expect(page.getByText('Risposta per: Qual è la durata media?')).toBeVisible();
+    await expect(page.getByText('Manuale Demo (Pagina 2)')).toBeVisible();
+    await page.getByRole('button', { name: '👍 Utile' }).click();
+    await expect(page.getByRole('button', { name: '👍 Utile' })).toHaveCSS('background-color', 'rgb(52, 168, 83)');
+  });
+
+  test('walks through the PDF upload wizard for an authenticated user', async ({ page }) => {
+    const auth = await setupAuthRoutes(page);
+    auth.authenticate();
+
+    const games = [
+      { id: 'game-1', name: 'Terraforming Mars', createdAt: new Date().toISOString() }
+    ];
+
+    await page.route(`${apiBase}/games`, async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(games)
+        });
+      } else if (route.request().method() === 'POST') {
+        const body = route.request().postDataJSON() as { name: string };
+        const newGame = { id: 'game-2', name: body.name, createdAt: new Date().toISOString() };
+        games.push(newGame);
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(newGame)
+        });
+      }
+    });
+
+    await page.route(`${apiBase}/games/game-1/pdfs`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ pdfs: [] })
+      });
+    });
+
+    await page.route(`${apiBase}/ingest/pdf`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ documentId: 'doc-123' })
+      });
+    });
+
+    await page.route(`${apiBase}/games/game-1/rulespec`, async (route) => {
+      if (route.request().method() === 'PUT') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: route.request().postData() ?? JSON.stringify({})
+        });
+      } else {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({})
+        });
+      }
+    });
+
+    await page.goto('/upload');
+
+    await expect(page.getByRole('heading', { name: 'PDF Import Wizard' })).toBeVisible({ timeout: 5000 });
+    await page.getByLabel('Existing games').selectOption('game-1');
+    await page.getByRole('button', { name: 'Confirm selection' }).click();
+
+    await page.setInputFiles('#fileInput', {
+      name: 'rules.pdf',
+      mimeType: 'application/pdf',
+      buffer: Buffer.from('%PDF-1.4 test file')
+    });
+
+    await page.getByRole('button', { name: 'Upload & Continue' }).click();
+
+    await expect(page.getByText('✅ PDF uploaded successfully! Document ID: doc-123')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Step 2: Parse PDF' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Parse PDF' }).click();
+    await expect(page.getByRole('heading', { name: 'Step 3: Review & Edit Rules' })).toBeVisible();
+
+    await page.getByRole('button', { name: 'Publish RuleSpec' }).click();
+
+    await expect(page.getByText('✅ RuleSpec published successfully!')).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Step 4: Published Successfully/i })).toBeVisible();
+  });
+
+  test('allows filtering logs after navigating as an authenticated user', async ({ page }) => {
+    await setupAuthRoutes(page);
+
+    await page.goto('/logs');
+
+    await expect(page.getByRole('heading', { name: 'Observability Dashboard' })).toBeVisible();
+
+    const filter = page.getByPlaceholder('Filter logs by message, request ID, or user ID...');
+    await filter.fill('req-002');
+    await expect(page.getByText('User logged in successfully')).toBeVisible();
+    await expect(page.locator('text=Application started')).toHaveCount(0);
+
+    await filter.fill('no results');
+    await expect(page.getByText('No logs found. Start using the application to generate logs.')).toBeVisible();
+  });
+});

--- a/apps/web/src/pages/__tests__/chat.test.tsx
+++ b/apps/web/src/pages/__tests__/chat.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ChatPage from '../chat';
+import { api } from '../../lib/api';
+
+jest.mock('../../lib/api', () => ({
+  api: {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn()
+  }
+}));
+
+const mockApi = api as jest.Mocked<typeof api>;
+
+const mockAuthResponse = {
+  user: {
+    id: 'user-1',
+    email: 'user@example.com',
+    displayName: 'User One',
+    role: 'Admin'
+  },
+  expiresAt: new Date().toISOString()
+};
+
+describe('ChatPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders login prompt when user is not authenticated', async () => {
+    mockApi.get.mockResolvedValueOnce(null);
+
+    render(<ChatPage />);
+
+    await waitFor(() => expect(mockApi.get).toHaveBeenCalledWith('/auth/me'));
+    expect(screen.getByRole('heading', { name: /Accesso richiesto/i })).toBeInTheDocument();
+    expect(screen.getByText(/Devi effettuare l'accesso per utilizzare la chat/i)).toBeInTheDocument();
+  });
+
+  it('sends a message and renders agent response for authenticated users', async () => {
+    mockApi.get.mockResolvedValue(mockAuthResponse);
+    mockApi.post.mockResolvedValueOnce({
+      answer: 'Il gioco supporta fino a 4 giocatori.',
+      sources: [
+        { title: 'Manuale Ufficiale', snippet: 'Sezione introduttiva', page: 3 }
+      ]
+    });
+
+    render(<ChatPage />);
+
+    await screen.findByRole('heading', { name: /MeepleAI Chat/i });
+
+    const user = userEvent.setup();
+    const input = screen.getByPlaceholderText(/Fai una domanda sul gioco/i);
+    await user.type(input, 'Quanti giocatori possono partecipare?');
+
+    const sendButton = screen.getByRole('button', { name: /Invia/i });
+    await user.click(sendButton);
+
+    await waitFor(() => expect(mockApi.post).toHaveBeenCalledWith('/agents/qa', {
+      gameId: 'demo-chess',
+      query: 'Quanti giocatori possono partecipare?'
+    }));
+
+    await screen.findByText('Il gioco supporta fino a 4 giocatori.');
+    expect(screen.getByText('Manuale Ufficiale (Pagina 3)')).toBeInTheDocument();
+    expect(screen.queryByText(/Errore nella comunicazione/i)).not.toBeInTheDocument();
+  });
+
+  it('shows an error and restores state when the agent request fails', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockApi.get.mockResolvedValue(mockAuthResponse);
+    mockApi.post.mockRejectedValueOnce(new Error('Network error'));
+
+    render(<ChatPage />);
+
+    await screen.findByRole('heading', { name: /MeepleAI Chat/i });
+
+    const user = userEvent.setup();
+    const input = screen.getByPlaceholderText(/Fai una domanda sul gioco/i);
+    await user.type(input, 'Ciao agente?');
+
+    const sendButton = screen.getByRole('button', { name: /Invia/i });
+    await user.click(sendButton);
+
+    await waitFor(() => expect(mockApi.post).toHaveBeenCalled());
+
+    await screen.findByText(/Errore nella comunicazione con l'agente/i);
+    await screen.findByText(/Nessun messaggio ancora/i);
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/apps/web/src/pages/__tests__/editor.test.tsx
+++ b/apps/web/src/pages/__tests__/editor.test.tsx
@@ -1,0 +1,232 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RuleSpecEditor from '../editor';
+import { api } from '../../lib/api';
+import { useRouter } from 'next/router';
+
+jest.mock('../../lib/api', () => ({
+  api: {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn()
+  }
+}));
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn()
+}));
+
+const mockApi = api as jest.Mocked<typeof api>;
+const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>;
+
+const createRouter = (overrides: Partial<ReturnType<typeof useRouter>> = {}) => ({
+  route: '/editor',
+  pathname: '/editor',
+  query: {},
+  asPath: '/editor',
+  basePath: '',
+  push: jest.fn(),
+  replace: jest.fn(),
+  reload: jest.fn(),
+  back: jest.fn(),
+  prefetch: jest.fn().mockResolvedValue(undefined),
+  beforePopState: jest.fn(),
+  isFallback: false,
+  isLocaleDomain: false,
+  isReady: true,
+  isPreview: false,
+  events: {
+    emit: jest.fn(),
+    on: jest.fn(),
+    off: jest.fn()
+  },
+  ...overrides
+});
+
+const getEditorTextarea = () => {
+  const textarea = screen.queryAllByRole('textbox').find((el) => el.tagName === 'TEXTAREA');
+  if (!textarea) {
+    throw new Error('Editor textarea not found');
+  }
+  return textarea as HTMLTextAreaElement;
+};
+
+describe('RuleSpecEditor', () => {
+  const authResponse = {
+    user: {
+      id: 'admin-1',
+      email: 'admin@example.com',
+      role: 'Admin'
+    },
+    expiresAt: new Date().toISOString()
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseRouter.mockReturnValue(createRouter());
+  });
+
+  it('prompts for authentication when no user is returned', async () => {
+    mockApi.get.mockResolvedValueOnce(null);
+
+    render(<RuleSpecEditor />);
+
+    await waitFor(() => expect(mockApi.get).toHaveBeenCalledWith('/auth/me'));
+    expect(screen.getByText(/Devi effettuare l'accesso per utilizzare l'editor/i)).toBeInTheDocument();
+  });
+
+  it('blocks access for users without editor permissions', async () => {
+    mockUseRouter.mockReturnValue(createRouter({ query: { gameId: 'demo-chess' } }));
+    mockApi.get.mockResolvedValueOnce({
+      user: { id: 'viewer-1', email: 'viewer@example.com', role: 'Viewer' },
+      expiresAt: new Date().toISOString()
+    });
+
+    render(<RuleSpecEditor />);
+
+    await screen.findByText(/Non hai i permessi necessari/i);
+  });
+
+  it('loads, validates and saves a RuleSpec for authorized users', async () => {
+    const user = userEvent.setup();
+
+    const initialSpec = {
+      gameId: 'demo-chess',
+      version: '1.0.0',
+      createdAt: new Date('2024-01-01').toISOString(),
+      rules: [
+        { id: 'rule-1', text: 'Initial rule text.' }
+      ]
+    };
+
+    const updatedSpec = {
+      ...initialSpec,
+      version: '2.0.0'
+    };
+
+    mockUseRouter.mockReturnValue(createRouter({ query: { gameId: 'demo-chess' } }));
+    mockApi.get.mockImplementation(async (path: string) => {
+      if (path === '/auth/me') {
+        return authResponse;
+      }
+      if (path === '/games/demo-chess/rulespec') {
+        return initialSpec;
+      }
+      return null;
+    });
+    mockApi.put.mockResolvedValueOnce(updatedSpec);
+
+    render(<RuleSpecEditor />);
+
+    await screen.findByText(/Editor RuleSpec/i);
+
+    await waitFor(() =>
+      expect(getEditorTextarea().value).toContain('"version": "1.0.0"')
+    );
+    const textarea = getEditorTextarea();
+
+    const newJson = JSON.stringify(updatedSpec, null, 2);
+    await user.clear(textarea);
+    fireEvent.change(textarea, { target: { value: newJson } });
+    fireEvent.blur(textarea);
+
+    const saveButton = await screen.findByRole('button', { name: /^Salva$/i });
+    expect(saveButton).toBeEnabled();
+
+    await user.click(saveButton);
+
+    await waitFor(() =>
+      expect(mockApi.put).toHaveBeenCalledWith('/games/demo-chess/rulespec', updatedSpec)
+    );
+    await screen.findByText(/RuleSpec salvato con successo/i);
+  });
+
+  it('surfaces backend errors when saving fails', async () => {
+    const user = userEvent.setup();
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const initialSpec = {
+      gameId: 'demo-risk',
+      version: '0.1.0',
+      createdAt: new Date('2024-06-15').toISOString(),
+      rules: [
+        { id: 'r-1', text: 'Rule text' }
+      ]
+    };
+
+    mockUseRouter.mockReturnValue(createRouter({ query: { gameId: 'demo-risk' } }));
+    mockApi.get.mockImplementation(async (path: string) => {
+      if (path === '/auth/me') {
+        return authResponse;
+      }
+      if (path === '/games/demo-risk/rulespec') {
+        return initialSpec;
+      }
+      return null;
+    });
+
+    mockApi.put.mockRejectedValueOnce(new Error('Save failed'));
+
+    render(<RuleSpecEditor />);
+
+    await screen.findByText(/Editor RuleSpec/i);
+
+    await waitFor(() =>
+      expect(getEditorTextarea().value).toContain('"version": "0.1.0"')
+    );
+    const textarea = getEditorTextarea();
+    const updatedSpec = { ...initialSpec, version: '0.2.0' };
+    const json = JSON.stringify(updatedSpec, null, 2);
+
+    await user.clear(textarea);
+    fireEvent.change(textarea, { target: { value: json } });
+    fireEvent.blur(textarea);
+
+    const saveButton = screen.getByRole('button', { name: /^Salva$/i });
+    await user.click(saveButton);
+
+    await waitFor(() => expect(mockApi.put).toHaveBeenCalled());
+    await screen.findByText('Save failed');
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('disables saving and shows validation error when JSON is invalid', async () => {
+    const user = userEvent.setup();
+
+    const initialSpec = {
+      gameId: 'demo-catan',
+      version: '1.0.0',
+      createdAt: new Date('2024-01-02').toISOString(),
+      rules: [
+        { id: 'rule-a', text: 'Setup details' }
+      ]
+    };
+
+    mockUseRouter.mockReturnValue(createRouter({ query: { gameId: 'demo-catan' } }));
+    mockApi.get.mockImplementation(async (path: string) => {
+      if (path === '/auth/me') {
+        return authResponse;
+      }
+      if (path === '/games/demo-catan/rulespec') {
+        return initialSpec;
+      }
+      return null;
+    });
+
+    render(<RuleSpecEditor />);
+
+    await screen.findByText(/Editor RuleSpec/i);
+
+    await waitFor(() =>
+      expect(getEditorTextarea().value).toContain('"version": "1.0.0"')
+    );
+    const textarea = getEditorTextarea();
+    await user.clear(textarea);
+    fireEvent.change(textarea, { target: { value: '{' } });
+
+    expect(screen.getByText(/Expected property name/i)).toBeInTheDocument();
+    const saveButton = screen.getByRole('button', { name: /^Salva$/i });
+    expect(saveButton).toBeDisabled();
+  });
+});

--- a/apps/web/src/pages/__tests__/logs.test.tsx
+++ b/apps/web/src/pages/__tests__/logs.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LogsPage from '../logs';
+
+describe('LogsPage', () => {
+  it('renders default logs and allows filtering by user id', async () => {
+    const user = userEvent.setup();
+
+    render(<LogsPage />);
+
+    await screen.findByText(/Application started/i);
+    expect(screen.getByText(/User logged in successfully/i)).toBeInTheDocument();
+
+    const filterInput = screen.getByPlaceholderText(/Filter logs/i);
+
+    await user.clear(filterInput);
+    await user.type(filterInput, 'user-123');
+
+    expect(screen.getByText(/User logged in successfully/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Application started/i)).not.toBeInTheDocument();
+  });
+
+  it('shows empty state when no logs match the filter', async () => {
+    const user = userEvent.setup();
+
+    render(<LogsPage />);
+
+    const filterInput = await screen.findByPlaceholderText(/Filter logs/i);
+
+    await user.clear(filterInput);
+    await user.type(filterInput, 'no-match');
+
+    expect(screen.getByText(/No logs found/i)).toBeInTheDocument();
+    expect(screen.getByText(/basic observability dashboard/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest suites for chat, logs, and editor pages covering auth, error, and state cases
- mock API client and Next.js router for deterministic page tests
- extend Playwright to cover authenticated journeys including chat, upload, and log review

## Testing
- `npm test -- --coverage`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68e25c9bcd6c8320aeaef626a62d4886