### PR TITLE
Add service unit tests for API logging, games, n8n, and PDF storage

### DIFF
--- a/apps/api/tests/Api.Tests/AiRequestLogServiceTests.cs
+++ b/apps/api/tests/Api.Tests/AiRequestLogServiceTests.cs
@@ -1,0 +1,188 @@
+using System.Linq;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+public class AiRequestLogServiceTests
+{
+    private static MeepleAiDbContext CreateInMemoryContext()
+    {
+        var connection = new SqliteConnection("Filename=:memory:");
+        connection.Open();
+
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        var context = new MeepleAiDbContext(options);
+        context.Database.EnsureCreated();
+        return context;
+    }
+
+    [Fact]
+    public async Task LogRequestAsync_PersistsLogEntry()
+    {
+        await using var dbContext = CreateInMemoryContext();
+        var loggerMock = new Mock<ILogger<AiRequestLogService>>();
+        var service = new AiRequestLogService(dbContext, loggerMock.Object);
+
+        await service.LogRequestAsync(
+            userId: "user-1",
+            gameId: "game-1",
+            endpoint: "qa",
+            query: "What is the setup?",
+            responseSnippet: "Setup details...",
+            latencyMs: 120,
+            tokenCount: 500,
+            confidence: 0.9,
+            status: "Success",
+            errorMessage: null,
+            ipAddress: "127.0.0.1",
+            userAgent: "agent",
+            ct: CancellationToken.None);
+
+        var logs = await dbContext.AiRequestLogs.ToListAsync();
+        Assert.Single(logs);
+
+        var log = logs[0];
+        Assert.Equal("user-1", log.UserId);
+        Assert.Equal("game-1", log.GameId);
+        Assert.Equal("qa", log.Endpoint);
+        Assert.Equal("What is the setup?", log.Query);
+        Assert.Equal("Setup details...", log.ResponseSnippet);
+        Assert.Equal(120, log.LatencyMs);
+        Assert.Equal(500, log.TokenCount);
+        Assert.Equal(0.9, log.Confidence);
+        Assert.Equal("Success", log.Status);
+        Assert.Equal("127.0.0.1", log.IpAddress);
+        Assert.Equal("agent", log.UserAgent);
+        Assert.True(log.CreatedAt > DateTime.UtcNow.AddMinutes(-5));
+    }
+
+    [Fact]
+    public async Task LogRequestAsync_WhenDbThrows_LogsError()
+    {
+        var dbContext = CreateInMemoryContext();
+        var loggerMock = new Mock<ILogger<AiRequestLogService>>();
+        var service = new AiRequestLogService(dbContext, loggerMock.Object);
+
+        await dbContext.DisposeAsync();
+
+        await service.LogRequestAsync(null, null, "qa", null, null, 10, ct: CancellationToken.None);
+
+        var errorInvocation = loggerMock.Invocations
+            .FirstOrDefault(invocation => invocation.Arguments.FirstOrDefault() is LogLevel level && level == LogLevel.Error);
+
+        Assert.NotNull(errorInvocation);
+        var state = errorInvocation!.Arguments[2];
+        Assert.Contains("Failed to log AI request", state.ToString());
+    }
+
+    [Fact]
+    public async Task GetRequestsAsync_AppliesFiltersAndPagination()
+    {
+        await using var dbContext = CreateInMemoryContext();
+        dbContext.AiRequestLogs.AddRange(
+            new AiRequestLogEntity
+            {
+                Endpoint = "qa",
+                UserId = "user-1",
+                GameId = "game-1",
+                CreatedAt = DateTime.UtcNow.AddMinutes(-10),
+                LatencyMs = 100,
+                Status = "Success"
+            },
+            new AiRequestLogEntity
+            {
+                Endpoint = "setup",
+                UserId = "user-2",
+                GameId = "game-1",
+                CreatedAt = DateTime.UtcNow.AddMinutes(-5),
+                LatencyMs = 200,
+                Status = "Error"
+            },
+            new AiRequestLogEntity
+            {
+                Endpoint = "qa",
+                UserId = "user-1",
+                GameId = "game-2",
+                CreatedAt = DateTime.UtcNow.AddMinutes(-1),
+                LatencyMs = 150,
+                Status = "Success"
+            });
+        await dbContext.SaveChangesAsync();
+
+        var loggerMock = new Mock<ILogger<AiRequestLogService>>();
+        var service = new AiRequestLogService(dbContext, loggerMock.Object);
+
+        var results = await service.GetRequestsAsync(
+            limit: 1,
+            offset: 0,
+            endpoint: "qa",
+            userId: "user-1",
+            gameId: "game-2",
+            ct: CancellationToken.None);
+
+        Assert.Single(results);
+        Assert.Equal("game-2", results[0].GameId);
+        Assert.Equal("qa", results[0].Endpoint);
+    }
+
+    [Fact]
+    public async Task GetStatsAsync_ComputesAggregates()
+    {
+        await using var dbContext = CreateInMemoryContext();
+        dbContext.AiRequestLogs.AddRange(
+            new AiRequestLogEntity
+            {
+                Endpoint = "qa",
+                UserId = "user-1",
+                GameId = "game-1",
+                CreatedAt = DateTime.UtcNow.AddHours(-2),
+                LatencyMs = 100,
+                TokenCount = 200,
+                Status = "Success"
+            },
+            new AiRequestLogEntity
+            {
+                Endpoint = "qa",
+                UserId = "user-2",
+                GameId = "game-1",
+                CreatedAt = DateTime.UtcNow.AddHours(-1),
+                LatencyMs = 300,
+                TokenCount = 100,
+                Status = "Error"
+            },
+            new AiRequestLogEntity
+            {
+                Endpoint = "setup",
+                UserId = "user-1",
+                GameId = "game-2",
+                CreatedAt = DateTime.UtcNow.AddMinutes(-30),
+                LatencyMs = 200,
+                TokenCount = 50,
+                Status = "Success"
+            });
+        await dbContext.SaveChangesAsync();
+
+        var loggerMock = new Mock<ILogger<AiRequestLogService>>();
+        var service = new AiRequestLogService(dbContext, loggerMock.Object);
+
+        var stats = await service.GetStatsAsync(
+            startDate: DateTime.UtcNow.AddHours(-3),
+            endDate: DateTime.UtcNow,
+            ct: CancellationToken.None);
+
+        Assert.Equal(3, stats.TotalRequests);
+        Assert.Equal(200, stats.AvgLatencyMs);
+        Assert.Equal(350, stats.TotalTokens);
+        Assert.Equal(2d / 3d, stats.SuccessRate, 3);
+        Assert.Equal(2, stats.EndpointCounts["qa"]);
+        Assert.Equal(1, stats.EndpointCounts["setup"]);
+    }
+}

--- a/apps/api/tests/Api.Tests/GameServiceTests.cs
+++ b/apps/api/tests/Api.Tests/GameServiceTests.cs
@@ -1,0 +1,108 @@
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+public class GameServiceTests
+{
+    private static MeepleAiDbContext CreateInMemoryContext()
+    {
+        var connection = new SqliteConnection("Filename=:memory:");
+        connection.Open();
+
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        var context = new MeepleAiDbContext(options);
+        context.Database.EnsureCreated();
+        return context;
+    }
+
+    [Fact]
+    public async Task CreateGameAsync_WhenRequestedIdProvided_NormalizesAndPersists()
+    {
+        await using var dbContext = CreateInMemoryContext();
+        var service = new GameService(dbContext);
+
+        var game = await service.CreateGameAsync("  My Game  ", "My Game.ID  ");
+
+        Assert.Equal("my-game-id", game.Id);
+        Assert.Equal("My Game", game.Name);
+
+        var stored = await dbContext.Games.FirstAsync();
+        Assert.Equal("my-game-id", stored.Id);
+    }
+
+    [Fact]
+    public async Task CreateGameAsync_WhenDuplicateId_Throws()
+    {
+        await using var dbContext = CreateInMemoryContext();
+        dbContext.Games.Add(new GameEntity { Id = "duplicate", Name = "Existing" });
+        await dbContext.SaveChangesAsync();
+
+        var service = new GameService(dbContext);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.CreateGameAsync("Another", "duplicate"));
+    }
+
+    [Fact]
+    public async Task CreateGameAsync_WhenDuplicateName_Throws()
+    {
+        await using var dbContext = CreateInMemoryContext();
+        dbContext.Games.Add(new GameEntity { Id = "existing", Name = "Existing Game" });
+        await dbContext.SaveChangesAsync();
+
+        var service = new GameService(dbContext);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.CreateGameAsync("Existing Game", "new-id"));
+    }
+
+    [Fact]
+    public async Task CreateGameAsync_UsesTimeProviderForCreatedAt()
+    {
+        await using var dbContext = CreateInMemoryContext();
+        var fixedTime = new DateTimeOffset(new DateTime(2024, 05, 01, 12, 0, 0, DateTimeKind.Utc));
+        var timeProvider = new FixedTimeProvider(fixedTime);
+        var service = new GameService(dbContext, timeProvider);
+
+        var game = await service.CreateGameAsync("Timed Game", null);
+
+        Assert.Equal(fixedTime.UtcDateTime, game.CreatedAt);
+    }
+
+    [Fact]
+    public async Task GetGamesAsync_ReturnsAlphabetical()
+    {
+        await using var dbContext = CreateInMemoryContext();
+        dbContext.Games.AddRange(
+            new GameEntity { Id = "b", Name = "Bravo" },
+            new GameEntity { Id = "c", Name = "Charlie" },
+            new GameEntity { Id = "a", Name = "Alpha" });
+        await dbContext.SaveChangesAsync();
+
+        var service = new GameService(dbContext);
+
+        var games = await service.GetGamesAsync();
+
+        Assert.Collection(
+            games,
+            g => Assert.Equal("Alpha", g.Name),
+            g => Assert.Equal("Bravo", g.Name),
+            g => Assert.Equal("Charlie", g.Name));
+    }
+
+    private sealed class FixedTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _value;
+
+        public FixedTimeProvider(DateTimeOffset value)
+        {
+            _value = value;
+        }
+
+        public override DateTimeOffset GetUtcNow() => _value;
+    }
+}

--- a/apps/api/tests/Api.Tests/N8nConfigServiceTests.cs
+++ b/apps/api/tests/Api.Tests/N8nConfigServiceTests.cs
@@ -1,0 +1,150 @@
+using System.Net.Http;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Models;
+using Api.Services;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+public class N8nConfigServiceTests
+{
+    private static MeepleAiDbContext CreateInMemoryContext()
+    {
+        var connection = new SqliteConnection("Filename=:memory:");
+        connection.Open();
+
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        var context = new MeepleAiDbContext(options);
+        context.Database.EnsureCreated();
+        return context;
+    }
+
+    private static N8nConfigService CreateService(MeepleAiDbContext dbContext, Mock<IHttpClientFactory>? httpClientFactoryMock = null)
+    {
+        httpClientFactoryMock ??= new Mock<IHttpClientFactory>();
+        httpClientFactoryMock
+            .Setup(f => f.CreateClient(It.IsAny<string>()))
+            .Returns(new HttpClient());
+
+        var configurationMock = new Mock<IConfiguration>();
+        configurationMock
+            .Setup(c => c[It.Is<string>(key => key == "N8N_ENCRYPTION_KEY")])
+            .Returns("test-encryption-key");
+
+        var loggerMock = new Mock<ILogger<N8nConfigService>>();
+
+        return new N8nConfigService(dbContext, httpClientFactoryMock.Object, configurationMock.Object, loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task CreateConfigAsync_PersistsConfigWithTrimmedValues()
+    {
+        await using var dbContext = CreateInMemoryContext();
+        var service = CreateService(dbContext);
+
+        var result = await service.CreateConfigAsync(
+            "user-1",
+            new CreateN8nConfigRequest("Config One", "https://example.com/", "secret", "https://webhook.test/"),
+            CancellationToken.None);
+
+        Assert.Equal("Config One", result.Name);
+        Assert.Equal("https://example.com", result.BaseUrl);
+        Assert.Equal("https://webhook.test", result.WebhookUrl);
+
+        var entity = await dbContext.N8nConfigs.FirstAsync();
+        Assert.Equal("user-1", entity.CreatedByUserId);
+        Assert.True(entity.IsActive);
+        Assert.NotEqual("secret", entity.ApiKeyEncrypted);
+    }
+
+    [Fact]
+    public async Task UpdateConfigAsync_ModifiesFields()
+    {
+        await using var dbContext = CreateInMemoryContext();
+        var service = CreateService(dbContext);
+
+        var created = await service.CreateConfigAsync(
+            "creator",
+            new CreateN8nConfigRequest("Original", "https://origin.com", "initial", "https://hook/"),
+            CancellationToken.None);
+
+        var entity = await dbContext.N8nConfigs.FirstAsync();
+        var previousUpdatedAt = entity.UpdatedAt;
+        var previousApiKey = entity.ApiKeyEncrypted;
+
+        var updated = await service.UpdateConfigAsync(
+            created.Id,
+            new UpdateN8nConfigRequest("Updated", "https://updated.com/", "new-secret", "https://hook/new/", false),
+            CancellationToken.None);
+
+        Assert.Equal("Updated", updated.Name);
+        Assert.Equal("https://updated.com", updated.BaseUrl);
+        Assert.Equal("https://hook/new", updated.WebhookUrl);
+        Assert.False(updated.IsActive);
+
+        var refreshed = await dbContext.N8nConfigs.FirstAsync();
+        Assert.Equal("Updated", refreshed.Name);
+        Assert.Equal("https://updated.com", refreshed.BaseUrl);
+        Assert.Equal("https://hook/new", refreshed.WebhookUrl);
+        Assert.False(refreshed.IsActive);
+        Assert.True(refreshed.UpdatedAt > previousUpdatedAt);
+        Assert.NotEqual(previousApiKey, refreshed.ApiKeyEncrypted);
+    }
+
+    [Fact]
+    public async Task UpdateConfigAsync_WhenNameConflicts_Throws()
+    {
+        await using var dbContext = CreateInMemoryContext();
+        var service = CreateService(dbContext);
+
+        var first = await service.CreateConfigAsync(
+            "user",
+            new CreateN8nConfigRequest("First", "https://one.com", "key1", null),
+            CancellationToken.None);
+
+        await service.CreateConfigAsync(
+            "user",
+            new CreateN8nConfigRequest("Second", "https://two.com", "key2", null),
+            CancellationToken.None);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.UpdateConfigAsync(
+            first.Id,
+            new UpdateN8nConfigRequest("Second", null, null, null, null),
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task DeleteConfigAsync_RemovesEntity()
+    {
+        await using var dbContext = CreateInMemoryContext();
+        var service = CreateService(dbContext);
+
+        var created = await service.CreateConfigAsync(
+            "user",
+            new CreateN8nConfigRequest("DeleteMe", "https://delete.com", "key", null),
+            CancellationToken.None);
+
+        var deleted = await service.DeleteConfigAsync(created.Id, CancellationToken.None);
+
+        Assert.True(deleted);
+        Assert.Empty(dbContext.N8nConfigs);
+    }
+
+    [Fact]
+    public async Task DeleteConfigAsync_WhenMissing_ReturnsFalse()
+    {
+        await using var dbContext = CreateInMemoryContext();
+        var service = CreateService(dbContext);
+
+        var deleted = await service.DeleteConfigAsync("missing", CancellationToken.None);
+
+        Assert.False(deleted);
+    }
+}

--- a/apps/api/tests/Api.Tests/PdfStorageServiceTests.cs
+++ b/apps/api/tests/Api.Tests/PdfStorageServiceTests.cs
@@ -1,0 +1,244 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+public class PdfStorageServiceTests
+{
+    private static MeepleAiDbContext CreateInMemoryContext()
+    {
+        var connection = new SqliteConnection("Filename=:memory:");
+        connection.Open();
+
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        var context = new MeepleAiDbContext(options);
+        context.Database.EnsureCreated();
+        return context;
+    }
+
+    private static PdfStorageService CreateService(
+        MeepleAiDbContext dbContext,
+        string storagePath,
+        Mock<IBackgroundTaskService> backgroundTaskMock,
+        Mock<IServiceScopeFactory>? scopeFactoryMock = null)
+    {
+        var configurationMock = new Mock<IConfiguration>();
+        configurationMock.Setup(c => c[It.Is<string>(key => key == "PDF_STORAGE_PATH")]).Returns(storagePath);
+
+        scopeFactoryMock ??= new Mock<IServiceScopeFactory>(MockBehavior.Strict);
+
+        var loggerMock = new Mock<ILogger<PdfStorageService>>();
+        var textExtractionService = new PdfTextExtractionService(Mock.Of<ILogger<PdfTextExtractionService>>());
+        var tableExtractionService = new PdfTableExtractionService(Mock.Of<ILogger<PdfTableExtractionService>>());
+
+        return new PdfStorageService(
+            dbContext,
+            scopeFactoryMock.Object,
+            configurationMock.Object,
+            loggerMock.Object,
+            textExtractionService,
+            tableExtractionService,
+            backgroundTaskMock.Object);
+    }
+
+    [Fact]
+    public async Task UploadPdfAsync_WithNullFile_ReturnsFailure()
+    {
+        await using var dbContext = CreateInMemoryContext();
+        dbContext.Games.Add(new GameEntity { Id = "game-1", Name = "Game" });
+        await dbContext.SaveChangesAsync();
+
+        var storagePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        try
+        {
+            var backgroundMock = new Mock<IBackgroundTaskService>();
+            var service = CreateService(dbContext, storagePath, backgroundMock);
+
+            var result = await service.UploadPdfAsync("game-1", "user", null!, CancellationToken.None);
+
+            Assert.False(result.Success);
+            Assert.Contains("No file provided", result.Message);
+            backgroundMock.Verify(b => b.Execute(It.IsAny<Func<Task>>()), Times.Never);
+        }
+        finally
+        {
+            if (Directory.Exists(storagePath))
+            {
+                Directory.Delete(storagePath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task UploadPdfAsync_WithTooLargeFile_ReturnsFailure()
+    {
+        await using var dbContext = CreateInMemoryContext();
+        dbContext.Games.Add(new GameEntity { Id = "game-1", Name = "Game" });
+        await dbContext.SaveChangesAsync();
+
+        var storagePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        try
+        {
+            var backgroundMock = new Mock<IBackgroundTaskService>();
+            var service = CreateService(dbContext, storagePath, backgroundMock);
+
+            var mockFile = new Mock<IFormFile>();
+            mockFile.Setup(f => f.Length).Returns(60L * 1024 * 1024);
+            mockFile.Setup(f => f.ContentType).Returns("application/pdf");
+            mockFile.Setup(f => f.FileName).Returns("large.pdf");
+
+            var result = await service.UploadPdfAsync("game-1", "user", mockFile.Object, CancellationToken.None);
+
+            Assert.False(result.Success);
+            Assert.Contains("File size exceeds", result.Message);
+            backgroundMock.Verify(b => b.Execute(It.IsAny<Func<Task>>()), Times.Never);
+        }
+        finally
+        {
+            if (Directory.Exists(storagePath))
+            {
+                Directory.Delete(storagePath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task UploadPdfAsync_WithInvalidContentType_ReturnsFailure()
+    {
+        await using var dbContext = CreateInMemoryContext();
+        dbContext.Games.Add(new GameEntity { Id = "game-1", Name = "Game" });
+        await dbContext.SaveChangesAsync();
+
+        var storagePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        try
+        {
+            var backgroundMock = new Mock<IBackgroundTaskService>();
+            var service = CreateService(dbContext, storagePath, backgroundMock);
+
+            var mockFile = new Mock<IFormFile>();
+            mockFile.Setup(f => f.Length).Returns(1024);
+            mockFile.Setup(f => f.ContentType).Returns("text/plain");
+            mockFile.Setup(f => f.FileName).Returns("notes.txt");
+
+            var result = await service.UploadPdfAsync("game-1", "user", mockFile.Object, CancellationToken.None);
+
+            Assert.False(result.Success);
+            Assert.Contains("Invalid file type", result.Message);
+            backgroundMock.Verify(b => b.Execute(It.IsAny<Func<Task>>()), Times.Never);
+        }
+        finally
+        {
+            if (Directory.Exists(storagePath))
+            {
+                Directory.Delete(storagePath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task UploadPdfAsync_WhenGameMissing_ReturnsFailure()
+    {
+        await using var dbContext = CreateInMemoryContext();
+
+        var storagePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        try
+        {
+            var backgroundMock = new Mock<IBackgroundTaskService>();
+            var service = CreateService(dbContext, storagePath, backgroundMock);
+
+            var file = CreateFormFile("rules.pdf", "application/pdf", new byte[] { 1, 2, 3 });
+
+            var result = await service.UploadPdfAsync("unknown", "user", file, CancellationToken.None);
+
+            Assert.False(result.Success);
+            Assert.Contains("Game not found", result.Message);
+            backgroundMock.Verify(b => b.Execute(It.IsAny<Func<Task>>()), Times.Never);
+        }
+        finally
+        {
+            if (Directory.Exists(storagePath))
+            {
+                Directory.Delete(storagePath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task UploadPdfAsync_WithValidFile_SavesDocumentAndSchedulesExtraction()
+    {
+        await using var dbContext = CreateInMemoryContext();
+        dbContext.Games.Add(new GameEntity { Id = "game-1", Name = "Game" });
+        await dbContext.SaveChangesAsync();
+
+        var storagePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Func<Task>? scheduledTask = null;
+        try
+        {
+            var backgroundMock = new Mock<IBackgroundTaskService>();
+            backgroundMock
+                .Setup(b => b.Execute(It.IsAny<Func<Task>>()))
+                .Callback<Func<Task>>(task => scheduledTask = task);
+
+            var scopeFactoryMock = new Mock<IServiceScopeFactory>(MockBehavior.Strict);
+
+            var service = CreateService(dbContext, storagePath, backgroundMock, scopeFactoryMock);
+
+            var file = CreateFormFile("rules.pdf", "application/pdf", new byte[] { 1, 2, 3, 4 });
+
+            var result = await service.UploadPdfAsync("game-1", "user", file, CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.NotNull(result.Document);
+            Assert.Equal("rules.pdf", result.Document!.FileName);
+
+            var gameDirectory = Path.Combine(storagePath, "game-1");
+            Assert.True(Directory.Exists(gameDirectory));
+            Assert.Single(Directory.GetFiles(gameDirectory));
+
+            var stored = await dbContext.PdfDocuments.FirstAsync();
+            Assert.Equal("game-1", stored.GameId);
+            Assert.Equal("application/pdf", stored.ContentType);
+            Assert.Equal("user", stored.UploadedByUserId);
+
+            Assert.NotNull(scheduledTask);
+        }
+        finally
+        {
+            if (Directory.Exists(storagePath))
+            {
+                Directory.Delete(storagePath, recursive: true);
+            }
+        }
+    }
+
+    private static IFormFile CreateFormFile(string fileName, string contentType, byte[] content)
+    {
+        var stream = new MemoryStream(content);
+        var mockFile = new Mock<IFormFile>();
+        mockFile.Setup(f => f.Length).Returns(content.Length);
+        mockFile.Setup(f => f.FileName).Returns(fileName);
+        mockFile.Setup(f => f.ContentType).Returns(contentType);
+        mockFile
+            .Setup(f => f.CopyToAsync(It.IsAny<Stream>(), It.IsAny<CancellationToken>()))
+            .Returns<Stream, CancellationToken>((target, token) =>
+            {
+                stream.Position = 0;
+                return stream.CopyToAsync(target, token);
+            });
+        return mockFile.Object;
+    }
+}


### PR DESCRIPTION
## Summary
- add in-memory SQLite unit tests for `AiRequestLogService` covering logging, filtering, and stats paths
- add `GameService` tests to verify ID normalization, duplicate detection, and time provider usage
- add `N8nConfigService` coverage for create/update/delete flows with encryption and validation guards
- add `PdfStorageService` tests validating upload guards and background extraction scheduling

## Testing
- `dotnet test` *(fails: `dotnet` CLI is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e25c96a158832097e908d0e27357b1