### PR TITLE
test: mock router forward in editor tests

### DIFF
--- a/apps/web/src/pages/__tests__/editor.test.tsx
+++ b/apps/web/src/pages/__tests__/editor.test.tsx
@@ -35,6 +35,7 @@ const createRouter = (overrides: Partial<ReturnType<typeof useRouter>> = {}) => 
   isLocaleDomain: false,
   isReady: true,
   isPreview: false,
+  forward: jest.fn(),
   events: {
     emit: jest.fn(),
     on: jest.fn(),


### PR DESCRIPTION
## Summary
- add a default jest mock for the next/router forward method in the editor tests so it can be overridden when needed

## Testing
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e26e710ab883208d4d7b8b21ff47fe