### PR TITLE
refactor: use IReadOnlyList in qdrant adapter

### DIFF
--- a/apps/api/src/Api/Services/IQdrantClientAdapter.cs
+++ b/apps/api/src/Api/Services/IQdrantClientAdapter.cs
@@ -7,7 +7,7 @@ namespace Api.Services;
 
 public interface IQdrantClientAdapter
 {
-    Task<IEnumerable<string>> ListCollectionsAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<string>> ListCollectionsAsync(CancellationToken cancellationToken = default);
     Task CreateCollectionAsync(
         string collectionName,
         VectorParams vectorsConfig,
@@ -19,9 +19,9 @@ public interface IQdrantClientAdapter
         CancellationToken cancellationToken = default);
     Task UpsertAsync(
         string collectionName,
-        IEnumerable<PointStruct> points,
+        IReadOnlyList<PointStruct> points,
         CancellationToken cancellationToken = default);
-    Task<IEnumerable<ScoredPoint>> SearchAsync(
+    Task<IReadOnlyList<ScoredPoint>> SearchAsync(
         string collectionName,
         float[] vector,
         Filter? filter = default,

--- a/apps/api/tests/Api.Tests/QdrantServiceTests.cs
+++ b/apps/api/tests/Api.Tests/QdrantServiceTests.cs
@@ -84,10 +84,10 @@ public class QdrantServiceTests
             }
         };
 
-        IEnumerable<PointStruct>? capturedPoints = null;
+        IReadOnlyList<PointStruct>? capturedPoints = null;
         _clientAdapterMock
-            .Setup(x => x.UpsertAsync(CollectionName, It.IsAny<IEnumerable<PointStruct>>(), It.IsAny<CancellationToken>()))
-            .Callback<string, IEnumerable<PointStruct>, CancellationToken>((_, points, _) => capturedPoints = points.ToList())
+            .Setup(x => x.UpsertAsync(CollectionName, It.IsAny<IReadOnlyList<PointStruct>>(), It.IsAny<CancellationToken>()))
+            .Callback<string, IReadOnlyList<PointStruct>, CancellationToken>((_, points, _) => capturedPoints = points.ToList())
             .Returns(Task.CompletedTask);
 
         var result = await _sut.IndexDocumentChunksAsync("game-1", "pdf-1", chunks);
@@ -124,7 +124,7 @@ public class QdrantServiceTests
         };
 
         _clientAdapterMock
-            .Setup(x => x.UpsertAsync(CollectionName, It.IsAny<IEnumerable<PointStruct>>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.UpsertAsync(CollectionName, It.IsAny<IReadOnlyList<PointStruct>>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("boom"));
 
         var result = await _sut.IndexDocumentChunksAsync("game-1", "pdf-1", chunks);


### PR DESCRIPTION
## Summary
- update the Qdrant client adapter interface to return IReadOnlyList for collection listing and search results
- convert enumerable responses to lists in the concrete adapter and accept IReadOnlyList inputs for upsert
- adjust Qdrant service tests to work with the new IReadOnlyList signatures

## Testing
- dotnet test *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2767e145c8320a123b03b12b7cc65