### PR TITLE
refactor: ensure qdrant upsert uses read-only list

### DIFF
--- a/apps/api/src/Api/Services/QdrantService.cs
+++ b/apps/api/src/Api/Services/QdrantService.cs
@@ -121,7 +121,7 @@ public class QdrantService : IQdrantService
 
             await _clientAdapter.UpsertAsync(
                 collectionName: CollectionName,
-                points: points,
+                points: points.AsReadOnly(),
                 cancellationToken: ct
             );
 

--- a/apps/api/tests/Api.Tests/QdrantServiceTests.cs
+++ b/apps/api/tests/Api.Tests/QdrantServiceTests.cs
@@ -87,7 +87,7 @@ public class QdrantServiceTests
         IReadOnlyList<PointStruct>? capturedPoints = null;
         _clientAdapterMock
             .Setup(x => x.UpsertAsync(CollectionName, It.IsAny<IReadOnlyList<PointStruct>>(), It.IsAny<CancellationToken>()))
-            .Callback<string, IReadOnlyList<PointStruct>, CancellationToken>((_, points, _) => capturedPoints = points.ToList())
+            .Callback<string, IReadOnlyList<PointStruct>, CancellationToken>((_, points, _) => capturedPoints = points)
             .Returns(Task.CompletedTask);
 
         var result = await _sut.IndexDocumentChunksAsync("game-1", "pdf-1", chunks);


### PR DESCRIPTION
## Summary
- pass a read-only list of points into the Qdrant adapter to match the IReadOnlyList contract
- adjust the service test callback to keep the captured IReadOnlyList instance without copying

## Testing
- `dotnet test` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e27731f7688320be42a657ef7a1b40