### PR TITLE
fix: honor override services during pdf vector indexing

### DIFF
--- a/apps/api/src/Api/Services/PdfStorageService.cs
+++ b/apps/api/src/Api/Services/PdfStorageService.cs
@@ -287,9 +287,12 @@ public class PdfStorageService
         // Create new scope for background task to avoid disposed DbContext
         using var scope = _scopeFactory.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
-        var chunkingService = scope.ServiceProvider.GetRequiredService<TextChunkingService>();
-        var embeddingService = scope.ServiceProvider.GetRequiredService<EmbeddingService>();
-        var qdrantService = scope.ServiceProvider.GetRequiredService<IQdrantService>();
+        var chunkingService = _textChunkingServiceOverride
+            ?? scope.ServiceProvider.GetRequiredService<ITextChunkingService>();
+        var embeddingService = _embeddingServiceOverride
+            ?? scope.ServiceProvider.GetRequiredService<IEmbeddingService>();
+        var qdrantService = _qdrantServiceOverride
+            ?? scope.ServiceProvider.GetRequiredService<IQdrantService>();
 
         try
         {

--- a/apps/api/tests/Api.Tests/PdfStorageServiceTests.cs
+++ b/apps/api/tests/Api.Tests/PdfStorageServiceTests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Api.Infrastructure;
@@ -34,7 +36,12 @@ public class PdfStorageServiceTests
         MeepleAiDbContext dbContext,
         string storagePath,
         Mock<IBackgroundTaskService> backgroundTaskMock,
-        Mock<IServiceScopeFactory>? scopeFactoryMock = null)
+        Mock<IServiceScopeFactory>? scopeFactoryMock = null,
+        PdfTextExtractionService? textExtractionService = null,
+        PdfTableExtractionService? tableExtractionService = null,
+        ITextChunkingService? textChunkingService = null,
+        IEmbeddingService? embeddingService = null,
+        IQdrantService? qdrantService = null)
     {
         var configurationMock = new Mock<IConfiguration>();
         configurationMock.Setup(c => c[It.Is<string>(key => key == "PDF_STORAGE_PATH")]).Returns(storagePath);
@@ -42,17 +49,17 @@ public class PdfStorageServiceTests
         scopeFactoryMock ??= new Mock<IServiceScopeFactory>(MockBehavior.Strict);
 
         var loggerMock = new Mock<ILogger<PdfStorageService>>();
-        var textExtractionService = new PdfTextExtractionService(Mock.Of<ILogger<PdfTextExtractionService>>());
-        var tableExtractionService = new PdfTableExtractionService(Mock.Of<ILogger<PdfTableExtractionService>>());
-
         return new PdfStorageService(
             dbContext,
             scopeFactoryMock.Object,
             configurationMock.Object,
             loggerMock.Object,
-            textExtractionService,
-            tableExtractionService,
-            backgroundTaskMock.Object);
+            textExtractionService ?? new PdfTextExtractionService(Mock.Of<ILogger<PdfTextExtractionService>>()),
+            tableExtractionService ?? new PdfTableExtractionService(Mock.Of<ILogger<PdfTableExtractionService>>()),
+            backgroundTaskMock.Object,
+            textChunkingService,
+            embeddingService,
+            qdrantService);
     }
 
     private static async Task SeedUserAsync(MeepleAiDbContext dbContext, string userId)
@@ -234,6 +241,160 @@ public class PdfStorageServiceTests
             Assert.Equal("user", stored.UploadedByUserId);
 
             Assert.NotNull(scheduledTask);
+        }
+        finally
+        {
+            if (Directory.Exists(storagePath))
+            {
+                Directory.Delete(storagePath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task IndexVectorsAsync_UsesOverridesWhenProvided()
+    {
+        await using var dbContext = CreateInMemoryContext();
+        dbContext.Games.Add(new GameEntity { Id = "game-1", Name = "Game" });
+        await dbContext.SaveChangesAsync();
+        await SeedUserAsync(dbContext, "user");
+
+        var storagePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var scheduledTasks = new List<Func<Task>>();
+
+        try
+        {
+            var backgroundMock = new Mock<IBackgroundTaskService>();
+            backgroundMock
+                .Setup(b => b.Execute(It.IsAny<Func<Task>>()))
+                .Callback<Func<Task>>(task => scheduledTasks.Add(task));
+
+            var scopeFactoryMock = new Mock<IServiceScopeFactory>();
+            var serviceProviderMock = new Mock<IServiceProvider>(MockBehavior.Strict);
+            serviceProviderMock
+                .Setup(sp => sp.GetService(typeof(MeepleAiDbContext)))
+                .Returns(dbContext);
+            serviceProviderMock
+                .Setup(sp => sp.GetService(typeof(PdfTableExtractionService)))
+                .Returns(null);
+            serviceProviderMock
+                .Setup(sp => sp.GetService(typeof(ITextChunkingService)))
+                .Throws(new InvalidOperationException("Scope chunking should not be used"));
+            serviceProviderMock
+                .Setup(sp => sp.GetService(typeof(IEmbeddingService)))
+                .Throws(new InvalidOperationException("Scope embedding should not be used"));
+            serviceProviderMock
+                .Setup(sp => sp.GetService(typeof(IQdrantService)))
+                .Throws(new InvalidOperationException("Scope Qdrant should not be used"));
+
+            var scopeMock = new Mock<IServiceScope>();
+            scopeMock.SetupGet(s => s.ServiceProvider).Returns(serviceProviderMock.Object);
+            scopeMock.Setup(s => s.Dispose());
+            scopeFactoryMock.Setup(s => s.CreateScope()).Returns(scopeMock.Object);
+
+            var textExtractionMock = new Mock<PdfTextExtractionService>(
+                MockBehavior.Strict,
+                Mock.Of<ILogger<PdfTextExtractionService>>());
+            textExtractionMock
+                .Setup(s => s.ExtractTextAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(PdfTextExtractionResult.CreateSuccess("chunk-one\nchunk-two", 1, 18));
+
+            var tableExtractionMock = new Mock<PdfTableExtractionService>(
+                MockBehavior.Strict,
+                Mock.Of<ILogger<PdfTableExtractionService>>());
+            tableExtractionMock
+                .Setup(s => s.ExtractStructuredContentAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(PdfStructuredExtractionResult.CreateSuccess(
+                    new List<PdfTable>(),
+                    new List<PdfDiagram>(),
+                    new List<string>()));
+
+            var chunkingMock = new Mock<ITextChunkingService>(MockBehavior.Strict);
+            var chunkInputs = new List<DocumentChunkInput>
+            {
+                new() { Text = "chunk-one", Page = 1, CharStart = 0, CharEnd = 8 },
+                new() { Text = "chunk-two", Page = 1, CharStart = 9, CharEnd = 17 }
+            };
+            chunkingMock
+                .Setup(c => c.PrepareForEmbedding(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+                .Returns<string, int, int>((text, _, _) =>
+                {
+                    Assert.Equal("chunk-one\nchunk-two", text);
+                    return chunkInputs;
+                });
+
+            var embeddingMock = new Mock<IEmbeddingService>(MockBehavior.Strict);
+            var embeddings = new List<float[]>
+            {
+                new float[] { 0.1f, 0.2f },
+                new float[] { 0.3f, 0.4f }
+            };
+            embeddingMock
+                .Setup(e => e.GenerateEmbeddingsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((List<string> texts, CancellationToken _) =>
+                {
+                    Assert.Equal(chunkInputs.Select(c => c.Text), texts);
+                    return EmbeddingResult.CreateSuccess(embeddings);
+                });
+
+            var qdrantMock = new Mock<IQdrantService>(MockBehavior.Strict);
+            qdrantMock
+                .Setup(q => q.IndexDocumentChunksAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<List<DocumentChunk>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string gameId, string pdfId, List<DocumentChunk> chunks, CancellationToken _) =>
+                {
+                    Assert.Equal("game-1", gameId);
+                    Assert.Equal(chunkInputs.Count, chunks.Count);
+                    for (var i = 0; i < chunks.Count; i++)
+                    {
+                        Assert.Equal(chunkInputs[i].Text, chunks[i].Text);
+                        Assert.Equal(embeddings[i], chunks[i].Embedding);
+                    }
+
+                    return IndexResult.CreateSuccess(chunks.Count);
+                });
+
+            var service = CreateService(
+                dbContext,
+                storagePath,
+                backgroundMock,
+                scopeFactoryMock,
+                textExtractionMock.Object,
+                tableExtractionMock.Object,
+                chunkingMock.Object,
+                embeddingMock.Object,
+                qdrantMock.Object);
+
+            var file = CreateFormFile("rules.pdf", "application/pdf", new byte[] { 1, 2, 3, 4 });
+            var uploadResult = await service.UploadPdfAsync("game-1", "user", file, CancellationToken.None);
+
+            Assert.True(uploadResult.Success);
+            Assert.Single(scheduledTasks);
+
+            var extractionTask = scheduledTasks.Single();
+            await extractionTask();
+
+            Assert.Equal(2, scheduledTasks.Count);
+
+            var indexingTask = scheduledTasks[1];
+            await indexingTask();
+
+            chunkingMock.Verify(
+                c => c.PrepareForEmbedding(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()),
+                Times.Once);
+            embeddingMock.Verify(
+                e => e.GenerateEmbeddingsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+            qdrantMock.Verify(
+                q => q.IndexDocumentChunksAsync(
+                    "game-1",
+                    It.IsAny<string>(),
+                    It.IsAny<List<DocumentChunk>>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- prefer injected override services in PdfStorageService when indexing PDF vectors
- allow tests to pass override dependencies into PdfStorageService and cover the override path

## Testing
- `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj` *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e284469d8883209e8052835838e851