### PR TITLE
Add PDF RuleSpec ingest endpoint and frontend integration

### DIFF
--- a/apps/api/tests/Api.Tests/PdfIngestEndpointsTests.cs
+++ b/apps/api/tests/Api.Tests/PdfIngestEndpointsTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests;
+
+public class PdfIngestEndpointsTests : IClassFixture<WebApplicationFactoryFixture>
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly WebApplicationFactoryFixture _factory;
+
+    public PdfIngestEndpointsTests(WebApplicationFactoryFixture factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task PostRulespecIngest_ReturnsGeneratedRuleSpec()
+    {
+        using var client = _factory.CreateClient();
+        var email = "pdf-ingest@example.com";
+        var cookies = await RegisterAndAuthenticateAsync(client, email);
+
+        const string gameId = "game-ingest";
+        const string pdfId = "pdf-ingest";
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var user = await db.Users.SingleAsync(u => u.Email == email);
+
+            db.Games.Add(new GameEntity
+            {
+                Id = gameId,
+                Name = "Ingest Game",
+                CreatedAt = DateTime.UtcNow
+            });
+
+            db.PdfDocuments.Add(new PdfDocumentEntity
+            {
+                Id = pdfId,
+                GameId = gameId,
+                FileName = "rules.pdf",
+                FilePath = "/tmp/rules.pdf",
+                FileSizeBytes = 2048,
+                UploadedByUserId = user.Id,
+                UploadedAt = DateTime.UtcNow,
+                AtomicRules = JsonSerializer.Serialize(new[]
+                {
+                    "[Table on page 4] Setup: Distribute four cards to each player"
+                })
+            });
+
+            await db.SaveChangesAsync();
+        }
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/ingest/pdf/{pdfId}/rulespec");
+        foreach (var cookie in cookies)
+        {
+            request.Headers.TryAddWithoutValidation("Cookie", cookie);
+        }
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var spec = await response.Content.ReadFromJsonAsync<RuleSpec>(JsonOptions);
+        Assert.NotNull(spec);
+        Assert.Equal(gameId, spec!.gameId);
+        Assert.Single(spec.rules);
+        Assert.Equal("Setup: Distribute four cards to each player", spec.rules[0].text);
+        Assert.Equal("4", spec.rules[0].page);
+    }
+
+    private static async Task<List<string>> RegisterAndAuthenticateAsync(HttpClient client, string email, string role = "Admin")
+    {
+        var registerRequest = new RegisterPayload(
+            email,
+            "Password123!",
+            "Test User",
+            role);
+
+        var response = await client.PostAsJsonAsync("/auth/register", registerRequest);
+        response.EnsureSuccessStatusCode();
+
+        if (!response.Headers.TryGetValues("Set-Cookie", out var setCookie))
+        {
+            return new List<string>();
+        }
+
+        return new List<string>(setCookie.Select(cookie => cookie.Split(';')[0]));
+    }
+}

--- a/apps/web/src/pages/__tests__/upload.test.tsx
+++ b/apps/web/src/pages/__tests__/upload.test.tsx
@@ -123,4 +123,85 @@ describe('UploadPage', () => {
 
     await waitFor(() => expect(uploadButton).not.toBeDisabled());
   });
+
+  it('parses an uploaded PDF using the rulespec ingest endpoint', async () => {
+    const authResponse = {
+      user: {
+        id: 'user-3',
+        email: 'user3@example.com',
+        role: 'Admin',
+        displayName: 'User Three'
+      },
+      expiresAt: new Date().toISOString()
+    };
+
+    const parsedSpec = {
+      gameId: 'game-parse',
+      version: 'ingest-20240101000000',
+      createdAt: new Date().toISOString(),
+      rules: [
+        {
+          id: 'r1',
+          text: 'Setup: Distribute four cards to each player',
+          section: null,
+          page: '4',
+          line: null
+        }
+      ]
+    };
+
+    mockFetch.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      const method = init?.method ?? 'GET';
+
+      if (url.endsWith('/auth/me')) {
+        return createJsonResponse(authResponse);
+      }
+
+      if (url.endsWith('/games') && method === 'GET') {
+        return createJsonResponse([
+          { id: 'game-parse', name: 'Parse Game', createdAt: new Date().toISOString() }
+        ]);
+      }
+
+      if (url.includes('/games/game-parse/pdfs')) {
+        return createJsonResponse({ pdfs: [] });
+      }
+
+      if (url.endsWith('/ingest/pdf') && method === 'POST') {
+        return createJsonResponse({ documentId: 'pdf-parse', fileName: 'rules.pdf' });
+      }
+
+      if (url.includes('/ingest/pdf/pdf-parse/rulespec') && method === 'POST') {
+        return createJsonResponse(parsedSpec);
+      }
+
+      throw new Error(`Unexpected fetch call to ${url}`);
+    });
+
+    render(<UploadPage />);
+
+    await waitFor(() => expect(screen.getByLabelText(/Existing games/i)).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /Confirm selection/i }));
+
+    const fileInput = screen.getByLabelText(/PDF File/i) as HTMLInputElement;
+    const file = new File(['pdf'], 'rules.pdf', { type: 'application/pdf' });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    const uploadButton = screen.getByRole('button', { name: /Upload & Continue/i });
+    await waitFor(() => expect(uploadButton).not.toBeDisabled());
+    fireEvent.click(uploadButton);
+
+    await waitFor(() => expect(screen.getByText(/PDF uploaded successfully/i)).toBeInTheDocument());
+
+    const parseButton = screen.getByRole('button', { name: /Parse PDF/i });
+    await waitFor(() => expect(parseButton).not.toBeDisabled());
+    fireEvent.click(parseButton);
+
+    await waitFor(() => expect(screen.getByText(/PDF parsed successfully/i)).toBeInTheDocument());
+
+    expect(screen.getByDisplayValue('Setup: Distribute four cards to each player')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('4')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- add a RuleSpecService helper and POST /ingest/pdf/{pdfId}/rulespec endpoint to build specs from stored atomic rules or extracted text
- replace the upload wizard mock parsing step with a call to the real ingest endpoint
- extend backend and frontend test coverage for the new RuleSpec generation flow

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e284065ef08320852580c02a89ea44