### PR TITLE
feat: add upload wizard polling for pdf processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,18 @@ scripts/, tools/, schemas/ ...
 
 Per altre linee guida consulta `agents.md` e i README specifici nelle rispettive app.
 
+## 📄 PDF Import Wizard
+
+Il wizard di import dei PDF (pagina `/upload`) guida editor e admin nell'intero flusso:
+
+1. **Selezione gioco** – scegli un gioco esistente e premi “Confirm selection”, oppure creane uno nuovo. L'upload resta disabilitato finché non c'è una conferma.
+2. **Upload PDF** – seleziona un file `.pdf` e premi “Upload & Continue”. L'app invia il file a `/ingest/pdf` e salva l'`documentId` restituito.
+3. **Parsing asincrono** – la fase “Parse” esegue polling automatico su `/pdfs/{documentId}/text` ogni pochi secondi, mostra la barra di avanzamento e rende visibili eventuali errori (`processingError`). Il pulsante di continuazione rimane disabilitato finché lo stato non diventa `completed`.
+4. **Review automatica** – non appena il backend segnala `processingStatus: completed`, il wizard carica la RuleSpec reale (`GET /games/{gameId}/rulespec`) e passa alla fase di review senza intervento manuale.
+5. **Pubblicazione** – dopo aver eventualmente modificato le regole estratte, premi “Publish RuleSpec” per inviare l'aggiornamento alle API.
+
+Se l'elaborazione fallisce (`processingStatus: failed`), il wizard mostra l'errore restituito e invita a ripartire dall'upload.
+
 ## Contribuire
 
 Accogliamo contributi dalla community! Prima di iniziare:
@@ -147,6 +159,7 @@ Accogliamo contributi dalla community! Prima di iniziare:
 - ✅ Health check endpoints
 - ✅ Integrazione con backend API
 - ✅ Gestione upload PDF con wizard multi-step con tracking avanzato dei progressi, connesso agli endpoint backend `/ingest/pdf` e `/games/{id}/pdfs`
+- ✅ Polling automatico dello stato di parsing (`/pdfs/{documentId}/text`) con barra di avanzamento e avanzamento automatico alla review
 
 #### Admin & Automazione
 - ✅ Dashboard amministrazione contenuti con log filtrabili, statistiche operative e gestione workflow n8n

--- a/apps/web/src/pages/__tests__/upload.test.tsx
+++ b/apps/web/src/pages/__tests__/upload.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import UploadPage from '../upload';
 
 describe('UploadPage', () => {
@@ -122,5 +122,118 @@ describe('UploadPage', () => {
     fireEvent.change(fileInput, { target: { files: [file] } });
 
     await waitFor(() => expect(uploadButton).not.toBeDisabled());
+  });
+
+  it('polls PDF processing status and auto advances to review when completed', async () => {
+    jest.useFakeTimers();
+
+    try {
+      const authResponse = {
+        user: {
+          id: 'user-3',
+          email: 'user3@example.com',
+          role: 'Admin',
+          displayName: 'User Three'
+        },
+        expiresAt: new Date().toISOString()
+      };
+
+      const ruleSpecResponse = {
+        gameId: 'game-1',
+        version: 'v1',
+        createdAt: new Date().toISOString(),
+        rules: [
+          { id: 'r1', text: 'Auto generated rule', section: 'Intro', page: '1', line: '1' }
+        ]
+      };
+
+      const statusSequence: Array<{ processingStatus: string; processingError?: string | null }> = [
+        { processingStatus: 'processing' },
+        { processingStatus: 'completed' }
+      ];
+
+      mockFetch.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        const method = init?.method ?? 'GET';
+
+        if (url.endsWith('/auth/me')) {
+          return createJsonResponse(authResponse);
+        }
+
+        if (url.endsWith('/games') && method === 'GET') {
+          return createJsonResponse([
+            { id: 'game-1', name: 'Terraforming Mars', createdAt: new Date().toISOString() }
+          ]);
+        }
+
+        if (url.includes('/games/game-1/pdfs')) {
+          return createJsonResponse({ pdfs: [] });
+        }
+
+        if (url.endsWith('/ingest/pdf')) {
+          return createJsonResponse({ documentId: 'pdf-123', fileName: 'rules.pdf' });
+        }
+
+        if (url.endsWith('/pdfs/pdf-123/text')) {
+          const nextStatus = statusSequence.shift() ?? { processingStatus: 'completed' };
+          return createJsonResponse({
+            id: 'pdf-123',
+            fileName: 'rules.pdf',
+            processingStatus: nextStatus.processingStatus,
+            processingError: nextStatus.processingError ?? null
+          });
+        }
+
+        if (url.endsWith('/games/game-1/rulespec')) {
+          return createJsonResponse(ruleSpecResponse);
+        }
+
+        throw new Error(`Unexpected fetch call to ${url}`);
+      });
+
+      render(<UploadPage />);
+
+      await waitFor(() => expect(screen.getByLabelText(/Existing games/i)).toBeInTheDocument());
+
+      fireEvent.click(screen.getByRole('button', { name: /Confirm selection/i }));
+
+      const fileInput = screen.getByLabelText(/PDF File/i) as HTMLInputElement;
+      const uploadButton = screen.getByRole('button', { name: /Upload & Continue/i });
+      const file = new File(['pdf'], 'rules.pdf', { type: 'application/pdf' });
+
+      fireEvent.change(fileInput, { target: { files: [file] } });
+      await waitFor(() => expect(uploadButton).not.toBeDisabled());
+
+      fireEvent.click(uploadButton);
+
+      await waitFor(() => expect(screen.getByText(/Processing status/i)).toBeInTheDocument());
+      expect(screen.getByText(/Processing status/i)).toHaveTextContent(/Processing status: (Pending|Processing)/i);
+
+      const continueButton = screen.getByRole('button', { name: /Waiting for processing/i });
+      expect(continueButton).toBeDisabled();
+
+      await waitFor(() =>
+        expect(screen.getByText(/Processing status/i)).toHaveTextContent('Processing')
+      );
+
+      await act(async () => {
+        jest.advanceTimersByTime(2000);
+      });
+
+      await waitFor(() =>
+        expect(screen.getByRole('heading', { name: /Step 3: Review & Edit Rules/i })).toBeInTheDocument()
+      );
+
+      await waitFor(() =>
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining('/games/game-1/rulespec'),
+          expect.objectContaining({ method: 'GET' })
+        )
+      );
+
+      await waitFor(() => expect(screen.getByText(/Auto generated rule/i)).toBeInTheDocument());
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/apps/web/src/pages/upload.tsx
+++ b/apps/web/src/pages/upload.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { api } from '../lib/api';
 
@@ -8,6 +8,19 @@ interface PdfDocument {
   fileSizeBytes: number;
   uploadedAt: string;
   uploadedByUserId: string;
+}
+
+type ProcessingStatus = 'pending' | 'processing' | 'completed' | 'failed';
+
+interface PdfProcessingResponse {
+  id: string;
+  fileName: string;
+  extractedText?: string | null;
+  processingStatus: ProcessingStatus;
+  processedAt?: string | null;
+  pageCount?: number | null;
+  characterCount?: number | null;
+  processingError?: string | null;
 }
 
 interface RuleAtom {
@@ -63,6 +76,10 @@ export default function UploadPage() {
   const [ruleSpec, setRuleSpec] = useState<RuleSpec | null>(null);
   const [pdfs, setPdfs] = useState<PdfDocument[]>([]);
   const [loadingPdfs, setLoadingPdfs] = useState(false);
+  const [processingStatus, setProcessingStatus] = useState<ProcessingStatus | null>(null);
+  const [processingError, setProcessingError] = useState<string | null>(null);
+  const [pollingError, setPollingError] = useState<string | null>(null);
+  const [autoAdvanceTriggered, setAutoAdvanceTriggered] = useState(false);
 
   const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
 
@@ -166,6 +183,10 @@ export default function UploadPage() {
         const data = await response.json();
         setDocumentId(data.documentId);
         setMessage(`✅ PDF uploaded successfully! Document ID: ${data.documentId}`);
+        setProcessingStatus('pending');
+        setProcessingError(null);
+        setPollingError(null);
+        setAutoAdvanceTriggered(false);
         setCurrentStep('parse');
       } else {
         const error = await response.json();
@@ -178,7 +199,7 @@ export default function UploadPage() {
     }
   };
 
-  const handleParse = async () => {
+  const handleParse = useCallback(async () => {
     if (!confirmedGameId) {
       setMessage('Please confirm a game before parsing');
       return;
@@ -188,38 +209,14 @@ export default function UploadPage() {
     setMessage('');
 
     try {
-      const mockRuleSpec: RuleSpec = {
-        gameId: confirmedGameId,
-        version: '1.0.0',
-        createdAt: new Date().toISOString(),
-        rules: [
-          {
-            id: '1',
-            text: 'Chess is played on a square board of eight rows and eight columns.',
-            section: 'Setup',
-            page: '1',
-            line: '1'
-          },
-          {
-            id: '2',
-            text: 'The game is played by two players, one controlling the white pieces and the other controlling the black pieces.',
-            section: 'Setup',
-            page: '1',
-            line: '3'
-          },
-          {
-            id: '3',
-            text: 'Each player begins the game with 16 pieces: one king, one queen, two rooks, two knights, two bishops, and eight pawns.',
-            section: 'Setup',
-            page: '1',
-            line: '5'
-          }
-        ]
-      };
+      const fetchedRuleSpec = await api.get<RuleSpec>(`/games/${confirmedGameId}/rulespec`);
 
-      await new Promise(resolve => setTimeout(resolve, 2000));
+      if (!fetchedRuleSpec) {
+        setMessage('❌ Parse failed: Unable to load RuleSpec.');
+        return;
+      }
 
-      setRuleSpec(mockRuleSpec);
+      setRuleSpec(fetchedRuleSpec);
       setMessage('✅ PDF parsed successfully!');
       setCurrentStep('review');
     } catch (error) {
@@ -227,7 +224,81 @@ export default function UploadPage() {
     } finally {
       setParsing(false);
     }
-  };
+  }, [confirmedGameId]);
+
+  useEffect(() => {
+    if (currentStep !== 'parse' || !documentId) {
+      return;
+    }
+
+    let cancelled = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    const pollStatus = async () => {
+      try {
+        const response = await fetch(`${API_BASE}/pdfs/${documentId}/text`, {
+          credentials: 'include'
+        });
+
+        if (!response.ok) {
+          const errorBody = await response.json().catch(() => null);
+          if (!cancelled) {
+            setPollingError(errorBody?.error ?? response.statusText);
+          }
+          if (!cancelled) {
+            timeout = setTimeout(pollStatus, 4000);
+          }
+          return;
+        }
+
+        const data: PdfProcessingResponse = await response.json();
+        if (cancelled) {
+          return;
+        }
+
+        setProcessingStatus(data.processingStatus);
+        setProcessingError(data.processingError ?? null);
+        setPollingError(null);
+
+        if (data.processingStatus === 'failed') {
+          setMessage(`❌ Parse failed: ${data.processingError ?? 'Processing failed. Please try again.'}`);
+          return;
+        }
+
+        if (data.processingStatus === 'completed') {
+          return;
+        }
+
+        timeout = setTimeout(pollStatus, 2000);
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+        setPollingError(error instanceof Error ? error.message : 'Unknown error');
+        timeout = setTimeout(pollStatus, 4000);
+      }
+    };
+
+    pollStatus();
+
+    return () => {
+      cancelled = true;
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    };
+  }, [API_BASE, currentStep, documentId]);
+
+  useEffect(() => {
+    if (currentStep !== 'parse') {
+      return;
+    }
+
+    if (processingStatus === 'completed' && !autoAdvanceTriggered) {
+      setAutoAdvanceTriggered(true);
+      void handleParse();
+    }
+  }, [autoAdvanceTriggered, currentStep, handleParse, processingStatus]);
 
   const handlePublish = async () => {
     if (!ruleSpec || !confirmedGameId) {
@@ -266,6 +337,10 @@ export default function UploadPage() {
     setDocumentId('');
     setRuleSpec(null);
     setMessage('');
+    setProcessingStatus(null);
+    setProcessingError(null);
+    setPollingError(null);
+    setAutoAdvanceTriggered(false);
     const fileInput = document.getElementById('fileInput') as HTMLInputElement;
     if (fileInput) {
       fileInput.value = '';
@@ -361,6 +436,20 @@ export default function UploadPage() {
 
   const selectedGame = games.find(game => game.id === selectedGameId) ?? null;
   const confirmedGame = confirmedGameId ? games.find(game => game.id === confirmedGameId) ?? null : null;
+  const statusLabels: Record<ProcessingStatus, string> = {
+    pending: 'Pending',
+    processing: 'Processing',
+    completed: 'Completed',
+    failed: 'Failed'
+  };
+  const statusProgress: Record<ProcessingStatus, number> = {
+    pending: 20,
+    processing: 65,
+    completed: 100,
+    failed: 100
+  };
+  const effectiveProcessingStatus: ProcessingStatus = processingStatus ?? 'pending';
+  const processingProgress = statusProgress[effectiveProcessingStatus];
 
   const renderStepIndicator = () => {
     const steps: WizardStep[] = ['upload', 'parse', 'review', 'publish'];
@@ -623,25 +712,75 @@ export default function UploadPage() {
           <p style={{ marginTop: '16px', marginBottom: '24px', color: '#666' }}>
             Document ID: <strong>{documentId}</strong>
           </p>
-          <p style={{ marginBottom: '24px' }}>
-            Click the button below to parse the PDF and extract rules.
-          </p>
+          <div style={{ marginBottom: '24px' }}>
+            <div
+              role="progressbar"
+              aria-label="PDF processing progress"
+              aria-valuenow={processingProgress}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              style={{
+                width: '100%',
+                backgroundColor: '#e5e7eb',
+                borderRadius: '999px',
+                height: '12px',
+                overflow: 'hidden',
+                marginBottom: '12px'
+              }}
+            >
+              <div
+                style={{
+                  width: `${processingProgress}%`,
+                  transition: 'width 0.6s ease',
+                  backgroundColor:
+                    effectiveProcessingStatus === 'completed'
+                      ? '#34a853'
+                      : effectiveProcessingStatus === 'failed'
+                        ? '#d93025'
+                        : '#0070f3',
+                  height: '100%'
+                }}
+              />
+            </div>
+            <p style={{ marginBottom: '8px', color: '#444' }}>
+              Processing status: <strong>{statusLabels[effectiveProcessingStatus]}</strong>
+            </p>
+            {pollingError && (
+              <p style={{ color: '#d93025', marginBottom: '8px' }}>
+                Status refresh failed: {pollingError}
+              </p>
+            )}
+            {processingError && effectiveProcessingStatus === 'failed' && (
+              <p style={{ color: '#d93025', marginBottom: '8px' }}>
+                Processing error: {processingError}
+              </p>
+            )}
+            <p style={{ marginBottom: '0', color: '#666' }}>
+              The wizard will automatically continue once processing is completed.
+            </p>
+          </div>
           <button
-            onClick={handleParse}
-            disabled={parsing}
+            onClick={() => void handleParse()}
+            disabled={parsing || effectiveProcessingStatus !== 'completed'}
             style={{
               padding: '12px 24px',
-              backgroundColor: parsing ? '#ccc' : '#0070f3',
+              backgroundColor:
+                parsing || effectiveProcessingStatus !== 'completed' ? '#ccc' : '#0070f3',
               color: 'white',
               border: 'none',
               borderRadius: '4px',
               fontSize: '16px',
-              cursor: parsing ? 'not-allowed' : 'pointer',
+              cursor:
+                parsing || effectiveProcessingStatus !== 'completed' ? 'not-allowed' : 'pointer',
               fontWeight: '500',
               marginRight: '12px'
             }}
           >
-            {parsing ? 'Parsing...' : 'Parse PDF'}
+            {effectiveProcessingStatus !== 'completed'
+              ? 'Waiting for processing...'
+              : parsing
+                ? 'Loading rules...'
+                : 'Continue to review'}
           </button>
           <button
             onClick={resetWizard}


### PR DESCRIPTION
## Summary
- poll `/pdfs/{documentId}/text` in the upload wizard, surface progress/errors, and auto-advance to review once parsing completes
- cover the new behaviour with a component test that mocks fetch responses and exercises the auto-transition
- update the README user guide with the revised PDF import wizard flow

## Testing
- npm test -- upload

------
https://chatgpt.com/codex/tasks/task_e_68e28406859483209a2f155c69a72670