### PR TITLE
test: add integration coverage for pdf vector overrides

### DIFF
--- a/apps/api/src/Api/Services/PdfStorageService.cs
+++ b/apps/api/src/Api/Services/PdfStorageService.cs
@@ -287,9 +287,12 @@ public class PdfStorageService
         // Create new scope for background task to avoid disposed DbContext
         using var scope = _scopeFactory.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
-        var chunkingService = scope.ServiceProvider.GetRequiredService<TextChunkingService>();
-        var embeddingService = scope.ServiceProvider.GetRequiredService<EmbeddingService>();
-        var qdrantService = scope.ServiceProvider.GetRequiredService<IQdrantService>();
+        var chunkingService = _textChunkingServiceOverride
+            ?? scope.ServiceProvider.GetRequiredService<ITextChunkingService>();
+        var embeddingService = _embeddingServiceOverride
+            ?? scope.ServiceProvider.GetRequiredService<IEmbeddingService>();
+        var qdrantService = _qdrantServiceOverride
+            ?? scope.ServiceProvider.GetRequiredService<IQdrantService>();
 
         try
         {

--- a/apps/api/tests/Api.Tests/PdfStorageServiceIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/PdfStorageServiceIntegrationTests.cs
@@ -1,0 +1,361 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Api.Tests;
+
+public class PdfStorageServiceIntegrationTests : PostgresIntegrationTestBase
+{
+    [Fact]
+    public async Task IndexVectorsAsync_UsesScopedServicesWhenOverridesAreNull()
+    {
+        var storagePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(storagePath);
+
+        try
+        {
+            // Arrange database entities
+            DbContext.Games.Add(new GameEntity { Id = "game-1", Name = "Test Game" });
+            DbContext.Users.Add(new UserEntity
+            {
+                Id = "user-1",
+                Email = "user1@example.com",
+                PasswordHash = "hash",
+                Role = UserRole.User,
+                CreatedAt = DateTime.UtcNow
+            });
+            await DbContext.SaveChangesAsync();
+
+            var scopeFactory = new CapturingScopeFactory(CreateScopedDbContext);
+            var backgroundService = new TestBackgroundTaskService();
+            var textExtractionService = new TestPdfTextExtractionService();
+            var tableExtractionService = new TestPdfTableExtractionService();
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["PDF_STORAGE_PATH"] = storagePath
+                })
+                .Build();
+
+            var service = new PdfStorageService(
+                DbContext,
+                scopeFactory,
+                configuration,
+                NullLogger<PdfStorageService>.Instance,
+                textExtractionService,
+                tableExtractionService,
+                backgroundService);
+
+            var file = CreateFormFile("rules.pdf", "application/pdf", new byte[] { 0x25, 0x50, 0x44, 0x46 });
+
+            // Act - upload triggers background extraction
+            var uploadResult = await service.UploadPdfAsync("game-1", "user-1", file, CancellationToken.None);
+
+            Assert.True(uploadResult.Success);
+            Assert.Equal(1, backgroundService.PendingTasks);
+
+            // Execute extraction task
+            await backgroundService.ExecuteNextAsync();
+
+            // Indexing should have been scheduled by extraction
+            Assert.Equal(1, backgroundService.PendingTasks);
+
+            // Execute indexing task
+            await backgroundService.ExecuteNextAsync();
+
+            Assert.Equal(0, backgroundService.PendingTasks);
+
+            // Assert chunking, embedding and qdrant services resolved from scope were used
+            var chunkingService = Assert.Single(scopeFactory.ChunkingServices.Where(c => c.PrepareForEmbeddingCallCount > 0));
+            Assert.Equal("chunk-one\nchunk-two", chunkingService.LastText);
+
+            var embeddingService = Assert.Single(scopeFactory.EmbeddingServices.Where(e => e.GenerateEmbeddingsCallCount > 0));
+            Assert.Equal(new[] { "chunk-one", "chunk-two" }, embeddingService.LastRequestedTexts);
+
+            var qdrantService = Assert.Single(scopeFactory.QdrantServices.Where(q => q.IndexCallCount > 0));
+            Assert.Equal("game-1", qdrantService.LastGameId);
+            Assert.Equal(uploadResult.Document!.Id, qdrantService.LastPdfId);
+            Assert.Equal(2, qdrantService.LastChunks!.Count);
+            Assert.All(qdrantService.LastChunks!, chunk => Assert.Equal(2, chunk.Embedding.Length));
+
+            await using var verificationContext = CreateScopedDbContext();
+            var vectorDoc = await verificationContext.VectorDocuments.SingleAsync();
+            Assert.Equal("completed", vectorDoc.IndexingStatus);
+            Assert.Equal(2, vectorDoc.ChunkCount);
+            Assert.Equal("chunk-one\nchunk-two".Length, vectorDoc.TotalCharacters);
+        }
+        finally
+        {
+            if (Directory.Exists(storagePath))
+            {
+                Directory.Delete(storagePath, recursive: true);
+            }
+        }
+    }
+
+    private static IFormFile CreateFormFile(string fileName, string contentType, byte[] content)
+    {
+        var stream = new MemoryStream(content);
+        var formFile = new FormFile(stream, 0, content.Length, "file", fileName)
+        {
+            Headers = new HeaderDictionary(),
+            ContentType = contentType
+        };
+
+        return formFile;
+    }
+
+    private sealed class TestBackgroundTaskService : IBackgroundTaskService
+    {
+        private readonly Queue<Func<Task>> _tasks = new();
+
+        public int PendingTasks => _tasks.Count;
+
+        public void Execute(Func<Task> task)
+        {
+            _tasks.Enqueue(task);
+        }
+
+        public async Task ExecuteNextAsync()
+        {
+            if (_tasks.Count == 0)
+            {
+                throw new InvalidOperationException("No background tasks scheduled");
+            }
+
+            var task = _tasks.Dequeue();
+            await task();
+        }
+    }
+
+    private sealed class TestPdfTextExtractionService : PdfTextExtractionService
+    {
+        private static readonly string Extracted = "chunk-one\nchunk-two";
+
+        public TestPdfTextExtractionService()
+            : base(NullLogger<PdfTextExtractionService>.Instance)
+        {
+        }
+
+        public override Task<PdfTextExtractionResult> ExtractTextAsync(string filePath, CancellationToken ct = default)
+        {
+            return Task.FromResult(PdfTextExtractionResult.CreateSuccess(Extracted, 1, Extracted.Length));
+        }
+    }
+
+    private sealed class TestPdfTableExtractionService : PdfTableExtractionService
+    {
+        public TestPdfTableExtractionService()
+            : base(NullLogger<PdfTableExtractionService>.Instance)
+        {
+        }
+
+        public override Task<PdfStructuredExtractionResult> ExtractStructuredContentAsync(string filePath, CancellationToken ct = default)
+        {
+            return Task.FromResult(PdfStructuredExtractionResult.CreateSuccess(new List<PdfTable>(), new List<PdfDiagram>(), new List<string>()));
+        }
+    }
+
+    private sealed class TestChunkingService : ITextChunkingService
+    {
+        public int PrepareForEmbeddingCallCount { get; private set; }
+        public string? LastText { get; private set; }
+
+        private static readonly List<DocumentChunkInput> Chunks = new()
+        {
+            new() { Text = "chunk-one", Page = 1, CharStart = 0, CharEnd = 9 },
+            new() { Text = "chunk-two", Page = 1, CharStart = 10, CharEnd = 19 }
+        };
+
+        public List<TextChunk> ChunkText(string text, int chunkSize = 512, int overlap = 50)
+        {
+            var index = 0;
+            return Chunks.Select(c => new TextChunk
+            {
+                Text = c.Text,
+                CharStart = c.CharStart,
+                CharEnd = c.CharEnd,
+                Page = c.Page,
+                Index = index++
+            }).ToList();
+        }
+
+        public List<DocumentChunkInput> PrepareForEmbedding(string text, int chunkSize = 512, int overlap = 50)
+        {
+            PrepareForEmbeddingCallCount++;
+            LastText = text;
+            return Chunks;
+        }
+    }
+
+    private sealed class TestEmbeddingService : IEmbeddingService
+    {
+        public int GenerateEmbeddingsCallCount { get; private set; }
+        public IReadOnlyList<string>? LastRequestedTexts { get; private set; }
+
+        private static readonly List<float[]> Embeddings = new()
+        {
+            new float[] { 0.1f, 0.2f },
+            new float[] { 0.3f, 0.4f }
+        };
+
+        public Task<EmbeddingResult> GenerateEmbeddingsAsync(List<string> texts, CancellationToken ct = default)
+        {
+            GenerateEmbeddingsCallCount++;
+            LastRequestedTexts = texts;
+            return Task.FromResult(EmbeddingResult.CreateSuccess(Embeddings));
+        }
+
+        public Task<EmbeddingResult> GenerateEmbeddingAsync(string text, CancellationToken ct = default)
+        {
+            return GenerateEmbeddingsAsync(new List<string> { text }, ct);
+        }
+    }
+
+    private sealed class TestQdrantService : IQdrantService
+    {
+        public int IndexCallCount { get; private set; }
+        public string? LastGameId { get; private set; }
+        public string? LastPdfId { get; private set; }
+        public List<DocumentChunk>? LastChunks { get; private set; }
+
+        public Task EnsureCollectionExistsAsync(CancellationToken ct = default)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task<IndexResult> IndexDocumentChunksAsync(string gameId, string pdfId, List<DocumentChunk> chunks, CancellationToken ct = default)
+        {
+            IndexCallCount++;
+            LastGameId = gameId;
+            LastPdfId = pdfId;
+            LastChunks = chunks.Select(chunk => new DocumentChunk
+            {
+                Text = chunk.Text,
+                Embedding = chunk.Embedding.ToArray(),
+                Page = chunk.Page,
+                CharStart = chunk.CharStart,
+                CharEnd = chunk.CharEnd
+            }).ToList();
+
+            return Task.FromResult(IndexResult.CreateSuccess(chunks.Count));
+        }
+
+        public Task<SearchResult> SearchAsync(string gameId, float[] queryEmbedding, int limit = 5, CancellationToken ct = default)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<bool> DeleteDocumentAsync(string pdfId, CancellationToken ct = default)
+        {
+            return Task.FromResult(true);
+        }
+    }
+
+    private sealed class CapturingScopeFactory : IServiceScopeFactory
+    {
+        private readonly Func<MeepleAiDbContext> _dbContextFactory;
+
+        public List<TestChunkingService> ChunkingServices { get; } = new();
+        public List<TestEmbeddingService> EmbeddingServices { get; } = new();
+        public List<TestQdrantService> QdrantServices { get; } = new();
+
+        public CapturingScopeFactory(Func<MeepleAiDbContext> dbContextFactory)
+        {
+            _dbContextFactory = dbContextFactory;
+        }
+
+        public IServiceScope CreateScope()
+        {
+            var dbContext = _dbContextFactory();
+            var chunking = new TestChunkingService();
+            var embedding = new TestEmbeddingService();
+            var qdrant = new TestQdrantService();
+
+            ChunkingServices.Add(chunking);
+            EmbeddingServices.Add(embedding);
+            QdrantServices.Add(qdrant);
+
+            return new CapturingScope(dbContext, chunking, embedding, qdrant);
+        }
+
+        private sealed class CapturingScope : IServiceScope
+        {
+            private readonly MeepleAiDbContext _dbContext;
+
+            public IServiceProvider ServiceProvider { get; }
+
+            public CapturingScope(
+                MeepleAiDbContext dbContext,
+                TestChunkingService chunkingService,
+                TestEmbeddingService embeddingService,
+                TestQdrantService qdrantService)
+            {
+                _dbContext = dbContext;
+                ServiceProvider = new CapturingServiceProvider(dbContext, chunkingService, embeddingService, qdrantService);
+            }
+
+            public void Dispose()
+            {
+                _dbContext.Dispose();
+            }
+        }
+
+        private sealed class CapturingServiceProvider : IServiceProvider
+        {
+            private readonly MeepleAiDbContext _dbContext;
+            private readonly TestChunkingService _chunkingService;
+            private readonly TestEmbeddingService _embeddingService;
+            private readonly TestQdrantService _qdrantService;
+
+            public CapturingServiceProvider(
+                MeepleAiDbContext dbContext,
+                TestChunkingService chunkingService,
+                TestEmbeddingService embeddingService,
+                TestQdrantService qdrantService)
+            {
+                _dbContext = dbContext;
+                _chunkingService = chunkingService;
+                _embeddingService = embeddingService;
+                _qdrantService = qdrantService;
+            }
+
+            public object? GetService(Type serviceType)
+            {
+                if (serviceType == typeof(MeepleAiDbContext))
+                {
+                    return _dbContext;
+                }
+
+                if (serviceType == typeof(ITextChunkingService))
+                {
+                    return _chunkingService;
+                }
+
+                if (serviceType == typeof(IEmbeddingService))
+                {
+                    return _embeddingService;
+                }
+
+                if (serviceType == typeof(IQdrantService))
+                {
+                    return _qdrantService;
+                }
+
+                return null;
+            }
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/PdfStorageServiceTests.cs
+++ b/apps/api/tests/Api.Tests/PdfStorageServiceTests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Api.Infrastructure;
@@ -34,7 +36,12 @@ public class PdfStorageServiceTests
         MeepleAiDbContext dbContext,
         string storagePath,
         Mock<IBackgroundTaskService> backgroundTaskMock,
-        Mock<IServiceScopeFactory>? scopeFactoryMock = null)
+        Mock<IServiceScopeFactory>? scopeFactoryMock = null,
+        PdfTextExtractionService? textExtractionService = null,
+        PdfTableExtractionService? tableExtractionService = null,
+        ITextChunkingService? textChunkingService = null,
+        IEmbeddingService? embeddingService = null,
+        IQdrantService? qdrantService = null)
     {
         var configurationMock = new Mock<IConfiguration>();
         configurationMock.Setup(c => c[It.Is<string>(key => key == "PDF_STORAGE_PATH")]).Returns(storagePath);
@@ -42,17 +49,17 @@ public class PdfStorageServiceTests
         scopeFactoryMock ??= new Mock<IServiceScopeFactory>(MockBehavior.Strict);
 
         var loggerMock = new Mock<ILogger<PdfStorageService>>();
-        var textExtractionService = new PdfTextExtractionService(Mock.Of<ILogger<PdfTextExtractionService>>());
-        var tableExtractionService = new PdfTableExtractionService(Mock.Of<ILogger<PdfTableExtractionService>>());
-
         return new PdfStorageService(
             dbContext,
             scopeFactoryMock.Object,
             configurationMock.Object,
             loggerMock.Object,
-            textExtractionService,
-            tableExtractionService,
-            backgroundTaskMock.Object);
+            textExtractionService ?? new PdfTextExtractionService(Mock.Of<ILogger<PdfTextExtractionService>>()),
+            tableExtractionService ?? new PdfTableExtractionService(Mock.Of<ILogger<PdfTableExtractionService>>()),
+            backgroundTaskMock.Object,
+            textChunkingService,
+            embeddingService,
+            qdrantService);
     }
 
     private static async Task SeedUserAsync(MeepleAiDbContext dbContext, string userId)
@@ -234,6 +241,160 @@ public class PdfStorageServiceTests
             Assert.Equal("user", stored.UploadedByUserId);
 
             Assert.NotNull(scheduledTask);
+        }
+        finally
+        {
+            if (Directory.Exists(storagePath))
+            {
+                Directory.Delete(storagePath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task IndexVectorsAsync_UsesOverridesWhenProvided()
+    {
+        await using var dbContext = CreateInMemoryContext();
+        dbContext.Games.Add(new GameEntity { Id = "game-1", Name = "Game" });
+        await dbContext.SaveChangesAsync();
+        await SeedUserAsync(dbContext, "user");
+
+        var storagePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var scheduledTasks = new List<Func<Task>>();
+
+        try
+        {
+            var backgroundMock = new Mock<IBackgroundTaskService>();
+            backgroundMock
+                .Setup(b => b.Execute(It.IsAny<Func<Task>>()))
+                .Callback<Func<Task>>(task => scheduledTasks.Add(task));
+
+            var scopeFactoryMock = new Mock<IServiceScopeFactory>();
+            var serviceProviderMock = new Mock<IServiceProvider>(MockBehavior.Strict);
+            serviceProviderMock
+                .Setup(sp => sp.GetService(typeof(MeepleAiDbContext)))
+                .Returns(dbContext);
+            serviceProviderMock
+                .Setup(sp => sp.GetService(typeof(PdfTableExtractionService)))
+                .Returns(null);
+            serviceProviderMock
+                .Setup(sp => sp.GetService(typeof(ITextChunkingService)))
+                .Throws(new InvalidOperationException("Scope chunking should not be used"));
+            serviceProviderMock
+                .Setup(sp => sp.GetService(typeof(IEmbeddingService)))
+                .Throws(new InvalidOperationException("Scope embedding should not be used"));
+            serviceProviderMock
+                .Setup(sp => sp.GetService(typeof(IQdrantService)))
+                .Throws(new InvalidOperationException("Scope Qdrant should not be used"));
+
+            var scopeMock = new Mock<IServiceScope>();
+            scopeMock.SetupGet(s => s.ServiceProvider).Returns(serviceProviderMock.Object);
+            scopeMock.Setup(s => s.Dispose());
+            scopeFactoryMock.Setup(s => s.CreateScope()).Returns(scopeMock.Object);
+
+            var textExtractionMock = new Mock<PdfTextExtractionService>(
+                MockBehavior.Strict,
+                Mock.Of<ILogger<PdfTextExtractionService>>());
+            textExtractionMock
+                .Setup(s => s.ExtractTextAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(PdfTextExtractionResult.CreateSuccess("chunk-one\nchunk-two", 1, 18));
+
+            var tableExtractionMock = new Mock<PdfTableExtractionService>(
+                MockBehavior.Strict,
+                Mock.Of<ILogger<PdfTableExtractionService>>());
+            tableExtractionMock
+                .Setup(s => s.ExtractStructuredContentAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(PdfStructuredExtractionResult.CreateSuccess(
+                    new List<PdfTable>(),
+                    new List<PdfDiagram>(),
+                    new List<string>()));
+
+            var chunkingMock = new Mock<ITextChunkingService>(MockBehavior.Strict);
+            var chunkInputs = new List<DocumentChunkInput>
+            {
+                new() { Text = "chunk-one", Page = 1, CharStart = 0, CharEnd = 8 },
+                new() { Text = "chunk-two", Page = 1, CharStart = 9, CharEnd = 17 }
+            };
+            chunkingMock
+                .Setup(c => c.PrepareForEmbedding(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+                .Returns<string, int, int>((text, _, _) =>
+                {
+                    Assert.Equal("chunk-one\nchunk-two", text);
+                    return chunkInputs;
+                });
+
+            var embeddingMock = new Mock<IEmbeddingService>(MockBehavior.Strict);
+            var embeddings = new List<float[]>
+            {
+                new float[] { 0.1f, 0.2f },
+                new float[] { 0.3f, 0.4f }
+            };
+            embeddingMock
+                .Setup(e => e.GenerateEmbeddingsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((List<string> texts, CancellationToken _) =>
+                {
+                    Assert.Equal(chunkInputs.Select(c => c.Text), texts);
+                    return EmbeddingResult.CreateSuccess(embeddings);
+                });
+
+            var qdrantMock = new Mock<IQdrantService>(MockBehavior.Strict);
+            qdrantMock
+                .Setup(q => q.IndexDocumentChunksAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<List<DocumentChunk>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string gameId, string pdfId, List<DocumentChunk> chunks, CancellationToken _) =>
+                {
+                    Assert.Equal("game-1", gameId);
+                    Assert.Equal(chunkInputs.Count, chunks.Count);
+                    for (var i = 0; i < chunks.Count; i++)
+                    {
+                        Assert.Equal(chunkInputs[i].Text, chunks[i].Text);
+                        Assert.Equal(embeddings[i], chunks[i].Embedding);
+                    }
+
+                    return IndexResult.CreateSuccess(chunks.Count);
+                });
+
+            var service = CreateService(
+                dbContext,
+                storagePath,
+                backgroundMock,
+                scopeFactoryMock,
+                textExtractionMock.Object,
+                tableExtractionMock.Object,
+                chunkingMock.Object,
+                embeddingMock.Object,
+                qdrantMock.Object);
+
+            var file = CreateFormFile("rules.pdf", "application/pdf", new byte[] { 1, 2, 3, 4 });
+            var uploadResult = await service.UploadPdfAsync("game-1", "user", file, CancellationToken.None);
+
+            Assert.True(uploadResult.Success);
+            Assert.Single(scheduledTasks);
+
+            var extractionTask = scheduledTasks.Single();
+            await extractionTask();
+
+            Assert.Equal(2, scheduledTasks.Count);
+
+            var indexingTask = scheduledTasks[1];
+            await indexingTask();
+
+            chunkingMock.Verify(
+                c => c.PrepareForEmbedding(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()),
+                Times.Once);
+            embeddingMock.Verify(
+                e => e.GenerateEmbeddingsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+            qdrantMock.Verify(
+                q => q.IndexDocumentChunksAsync(
+                    "game-1",
+                    It.IsAny<string>(),
+                    It.IsAny<List<DocumentChunk>>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- add a Postgres-backed integration test for `PdfStorageService` to ensure scoped chunking, embedding, and Qdrant services are used when no overrides are supplied

## Testing
- `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj` *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e284469d8883209e8052835838e851