### PR TITLE
fix: ensure n8n admin page uses API base fallback

### DIFF
--- a/apps/web/src/pages/__tests__/n8n.test.tsx
+++ b/apps/web/src/pages/__tests__/n8n.test.tsx
@@ -1,5 +1,11 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import N8nWorkflowManagement from '../n8n';
+
+const initialApiBaseEnv = process.env.NEXT_PUBLIC_API_BASE;
+if (!process.env.NEXT_PUBLIC_API_BASE) {
+  process.env.NEXT_PUBLIC_API_BASE = 'http://api.test';
+}
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const N8nWorkflowManagement = require('../n8n').default;
 
 type Deferred<T> = {
   promise: Promise<T>;
@@ -31,6 +37,7 @@ const getFormInputs = () => ({
 });
 
 describe('N8nWorkflowManagement', () => {
+  const originalApiBase = initialApiBaseEnv;
   const originalFetch = global.fetch;
   const originalConfirm = window.confirm;
   const originalAlert = window.alert;
@@ -55,6 +62,21 @@ describe('N8nWorkflowManagement', () => {
     global.fetch = originalFetch;
     window.confirm = originalConfirm;
     window.alert = originalAlert;
+    if (originalApiBase === undefined) {
+      delete process.env.NEXT_PUBLIC_API_BASE;
+    } else {
+      process.env.NEXT_PUBLIC_API_BASE = originalApiBase;
+    }
+  });
+
+  it('uses default API base when NEXT_PUBLIC_API_BASE is not defined', () => {
+    delete process.env.NEXT_PUBLIC_API_BASE;
+
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { apiBase } = require('../n8n');
+      expect(apiBase).toBe('http://localhost:8080');
+    });
   });
 
   it('shows loading state while fetch is pending', async () => {

--- a/apps/web/src/pages/n8n.tsx
+++ b/apps/web/src/pages/n8n.tsx
@@ -19,6 +19,8 @@ type TestResult = {
   latencyMs: number | null;
 };
 
+export const apiBase = process.env.NEXT_PUBLIC_API_BASE || "http://localhost:8080";
+
 export default function N8nWorkflowManagement() {
   const [configs, setConfigs] = useState<N8nConfig[]>([]);
   const [loading, setLoading] = useState(true);
@@ -41,7 +43,7 @@ export default function N8nWorkflowManagement() {
   const fetchConfigs = async () => {
     try {
       setLoading(true);
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/admin/n8n`, {
+      const res = await fetch(`${apiBase}/admin/n8n`, {
         credentials: "include"
       });
 
@@ -63,8 +65,8 @@ export default function N8nWorkflowManagement() {
 
     try {
       const url = editingConfig
-        ? `${process.env.NEXT_PUBLIC_API_BASE}/admin/n8n/${editingConfig.id}`
-        : `${process.env.NEXT_PUBLIC_API_BASE}/admin/n8n`;
+        ? `${apiBase}/admin/n8n/${editingConfig.id}`
+        : `${apiBase}/admin/n8n`;
 
       const method = editingConfig ? "PUT" : "POST";
 
@@ -120,7 +122,7 @@ export default function N8nWorkflowManagement() {
     }
 
     try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/admin/n8n/${configId}`, {
+      const res = await fetch(`${apiBase}/admin/n8n/${configId}`, {
         method: "DELETE",
         credentials: "include",
       });
@@ -138,7 +140,7 @@ export default function N8nWorkflowManagement() {
   const handleTest = async (configId: string) => {
     setTesting(configId);
     try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/admin/n8n/${configId}/test`, {
+      const res = await fetch(`${apiBase}/admin/n8n/${configId}/test`, {
         method: "POST",
         credentials: "include",
       });
@@ -159,7 +161,7 @@ export default function N8nWorkflowManagement() {
 
   const handleToggleActive = async (config: N8nConfig) => {
     try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/admin/n8n/${config.id}`, {
+      const res = await fetch(`${apiBase}/admin/n8n/${config.id}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         credentials: "include",


### PR DESCRIPTION
## Summary
- export and reuse an `apiBase` constant on the n8n admin page so every fetch shares the same fallback-aware endpoint base
- extend the n8n page tests with coverage for the default API base when `NEXT_PUBLIC_API_BASE` is unset

## Testing
- npm test -- n8n.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e2841763b08320a5a5a5028f8f8a7a