### PR TITLE
feat: capture llm usage metrics for admin logging

### DIFF
--- a/apps/api/src/Api/Infrastructure/Entities/AiRequestLogEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/AiRequestLogEntity.cs
@@ -9,11 +9,15 @@ public class AiRequestLogEntity
     public string? Query { get; set; }
     public string? ResponseSnippet { get; set; }
     public int LatencyMs { get; set; }
-    public int? TokenCount { get; set; }
+    public int TokenCount { get; set; }
+    public int PromptTokens { get; set; }
+    public int CompletionTokens { get; set; }
     public double? Confidence { get; set; }
     public string Status { get; set; } = default!; // "Success", "Error"
     public string? ErrorMessage { get; set; }
     public string? IpAddress { get; set; }
     public string? UserAgent { get; set; }
+    public string? Model { get; set; }
+    public string? FinishReason { get; set; }
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 }

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -243,12 +243,16 @@ public class MeepleAiDbContext : DbContext
             entity.Property(e => e.Query).HasMaxLength(2048);
             entity.Property(e => e.ResponseSnippet).HasMaxLength(1024);
             entity.Property(e => e.LatencyMs).IsRequired();
-            entity.Property(e => e.TokenCount);
+            entity.Property(e => e.TokenCount).HasDefaultValue(0);
+            entity.Property(e => e.PromptTokens).HasDefaultValue(0);
+            entity.Property(e => e.CompletionTokens).HasDefaultValue(0);
             entity.Property(e => e.Confidence);
             entity.Property(e => e.Status).IsRequired().HasMaxLength(32);
             entity.Property(e => e.ErrorMessage).HasMaxLength(1024);
             entity.Property(e => e.IpAddress).HasMaxLength(64);
             entity.Property(e => e.UserAgent).HasMaxLength(256);
+            entity.Property(e => e.Model).HasMaxLength(128);
+            entity.Property(e => e.FinishReason).HasMaxLength(64);
             entity.Property(e => e.CreatedAt).IsRequired();
             entity.HasIndex(e => e.CreatedAt);
             entity.HasIndex(e => e.Endpoint);

--- a/apps/api/src/Api/Migrations/20251101000000_AddLlmUsageMetadataToAiRequestLogs.Designer.cs
+++ b/apps/api/src/Api/Migrations/20251101000000_AddLlmUsageMetadataToAiRequestLogs.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Api.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251101000000_AddLlmUsageMetadataToAiRequestLogs")]
+    partial class AddLlmUsageMetadataToAiRequestLogs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -80,11 +83,11 @@ namespace Api.Migrations
                         .HasMaxLength(1024)
                         .HasColumnType("character varying(1024)");
 
-                    b.Property<string>("GameId")
+                    b.Property<string>("FinishReason")
                         .HasMaxLength(64)
                         .HasColumnType("character varying(64)");
 
-                    b.Property<string>("FinishReason")
+                    b.Property<string>("GameId")
                         .HasMaxLength(64)
                         .HasColumnType("character varying(64)");
 

--- a/apps/api/src/Api/Migrations/20251101000000_AddLlmUsageMetadataToAiRequestLogs.cs
+++ b/apps/api/src/Api/Migrations/20251101000000_AddLlmUsageMetadataToAiRequestLogs.cs
@@ -1,0 +1,82 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLlmUsageMetadataToAiRequestLogs : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("UPDATE ai_request_logs SET \"TokenCount\" = 0 WHERE \"TokenCount\" IS NULL;");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "TokenCount",
+                table: "ai_request_logs",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "CompletionTokens",
+                table: "ai_request_logs",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "FinishReason",
+                table: "ai_request_logs",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Model",
+                table: "ai_request_logs",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PromptTokens",
+                table: "ai_request_logs",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CompletionTokens",
+                table: "ai_request_logs");
+
+            migrationBuilder.DropColumn(
+                name: "FinishReason",
+                table: "ai_request_logs");
+
+            migrationBuilder.DropColumn(
+                name: "Model",
+                table: "ai_request_logs");
+
+            migrationBuilder.DropColumn(
+                name: "PromptTokens",
+                table: "ai_request_logs");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "TokenCount",
+                table: "ai_request_logs",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+        }
+    }
+}

--- a/apps/api/src/Api/Models/Contracts.cs
+++ b/apps/api/src/Api/Models/Contracts.cs
@@ -1,7 +1,16 @@
+using System.Collections.Generic;
+
 namespace Api.Models;
 
 public record QaRequest(string gameId, string query);
-public record QaResponse(string answer, IReadOnlyList<Snippet> snippets);
+public record QaResponse(
+    string answer,
+    IReadOnlyList<Snippet> snippets,
+    int promptTokens = 0,
+    int completionTokens = 0,
+    int totalTokens = 0,
+    double? confidence = null,
+    IReadOnlyDictionary<string, string>? metadata = null);
 public record Snippet(string text, string source, int page, int line);
 
 public record IngestPdfResponse(string jobId);
@@ -13,8 +22,11 @@ public record ExplainResponse(
     ExplainOutline outline,
     string script,
     IReadOnlyList<Snippet> citations,
-    int estimatedReadingTimeMinutes
-);
+    int estimatedReadingTimeMinutes,
+    int promptTokens = 0,
+    int completionTokens = 0,
+    int totalTokens = 0,
+    double? confidence = null);
 public record ExplainOutline(
     string mainTopic,
     IReadOnlyList<string> sections
@@ -25,8 +37,11 @@ public record SetupGuideRequest(string gameId);
 public record SetupGuideResponse(
     string gameTitle,
     IReadOnlyList<SetupGuideStep> steps,
-    int estimatedSetupTimeMinutes
-);
+    int estimatedSetupTimeMinutes,
+    int promptTokens = 0,
+    int completionTokens = 0,
+    int totalTokens = 0,
+    double? confidence = null);
 public record SetupGuideStep(
     int stepNumber,
     string title,

--- a/apps/api/src/Api/Services/AiRequestLogService.cs
+++ b/apps/api/src/Api/Services/AiRequestLogService.cs
@@ -27,6 +27,10 @@ public class AiRequestLogService
         string? errorMessage = null,
         string? ipAddress = null,
         string? userAgent = null,
+        int? promptTokens = null,
+        int? completionTokens = null,
+        string? model = null,
+        string? finishReason = null,
         CancellationToken ct = default)
     {
         try
@@ -39,12 +43,16 @@ public class AiRequestLogService
                 Query = query,
                 ResponseSnippet = responseSnippet,
                 LatencyMs = latencyMs,
-                TokenCount = tokenCount,
+                TokenCount = tokenCount ?? 0,
+                PromptTokens = promptTokens ?? 0,
+                CompletionTokens = completionTokens ?? 0,
                 Confidence = confidence,
                 Status = status,
                 ErrorMessage = errorMessage,
                 IpAddress = ipAddress,
                 UserAgent = userAgent,
+                Model = model,
+                FinishReason = finishReason,
                 CreatedAt = DateTime.UtcNow
             };
 
@@ -133,7 +141,7 @@ public class AiRequestLogService
 
         var totalRequests = await query.CountAsync(ct);
         var avgLatency = await query.AverageAsync(log => (double?)log.LatencyMs, ct) ?? 0;
-        var totalTokens = await query.SumAsync(log => log.TokenCount ?? 0, ct);
+        var totalTokens = await query.SumAsync(log => log.TokenCount, ct);
         var successCount = await query.CountAsync(log => log.Status == "Success", ct);
 
         var endpointCounts = await query

--- a/apps/api/src/Api/Services/ILlmService.cs
+++ b/apps/api/src/Api/Services/ILlmService.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Api.Services;
 
 /// <summary>
@@ -17,15 +19,31 @@ public interface ILlmService
 /// <summary>
 /// Result of LLM completion
 /// </summary>
+public record LlmUsage(int PromptTokens, int CompletionTokens, int TotalTokens)
+{
+    public static readonly LlmUsage Empty = new(0, 0, 0);
+}
+
 public record LlmCompletionResult
 {
     public bool Success { get; init; }
     public string? ErrorMessage { get; init; }
     public string Response { get; init; } = string.Empty;
+    public LlmUsage Usage { get; init; } = LlmUsage.Empty;
+    public IReadOnlyDictionary<string, string> Metadata { get; init; } = new Dictionary<string, string>();
 
-    public static LlmCompletionResult CreateSuccess(string response) =>
-        new() { Success = true, Response = response };
+    public static LlmCompletionResult CreateSuccess(
+        string response,
+        LlmUsage? usage = null,
+        IReadOnlyDictionary<string, string>? metadata = null) =>
+        new()
+        {
+            Success = true,
+            Response = response,
+            Usage = usage ?? LlmUsage.Empty,
+            Metadata = metadata ?? new Dictionary<string, string>()
+        };
 
     public static LlmCompletionResult CreateFailure(string error) =>
-        new() { Success = false, ErrorMessage = error };
+        new() { Success = false, ErrorMessage = error, Usage = LlmUsage.Empty, Metadata = new Dictionary<string, string>() };
 }

--- a/apps/api/tests/Api.Tests/AiRequestLogServiceTests.cs
+++ b/apps/api/tests/Api.Tests/AiRequestLogServiceTests.cs
@@ -44,6 +44,10 @@ public class AiRequestLogServiceTests
             errorMessage: null,
             ipAddress: "127.0.0.1",
             userAgent: "agent",
+            promptTokens: 300,
+            completionTokens: 200,
+            model: "anthropic/claude-3.5-sonnet",
+            finishReason: "stop",
             ct: CancellationToken.None);
 
         var logs = await dbContext.AiRequestLogs.ToListAsync();
@@ -57,10 +61,14 @@ public class AiRequestLogServiceTests
         Assert.Equal("Setup details...", log.ResponseSnippet);
         Assert.Equal(120, log.LatencyMs);
         Assert.Equal(500, log.TokenCount);
+        Assert.Equal(300, log.PromptTokens);
+        Assert.Equal(200, log.CompletionTokens);
         Assert.Equal(0.9, log.Confidence);
         Assert.Equal("Success", log.Status);
         Assert.Equal("127.0.0.1", log.IpAddress);
         Assert.Equal("agent", log.UserAgent);
+        Assert.Equal("anthropic/claude-3.5-sonnet", log.Model);
+        Assert.Equal("stop", log.FinishReason);
         Assert.True(log.CreatedAt > DateTime.UtcNow.AddMinutes(-5));
     }
 

--- a/apps/api/tests/Api.Tests/LlmServiceTests.cs
+++ b/apps/api/tests/Api.Tests/LlmServiceTests.cs
@@ -50,6 +50,8 @@ public class LlmServiceTests
         {
             var payload = new
             {
+                id = "resp_123",
+                model = "anthropic/claude-3.5-sonnet",
                 choices = new[]
                 {
                     new
@@ -57,8 +59,15 @@ public class LlmServiceTests
                         message = new
                         {
                             content = "Generated response"
-                        }
+                        },
+                        finish_reason = "stop"
                     }
+                },
+                usage = new
+                {
+                    prompt_tokens = 12,
+                    completion_tokens = 8,
+                    total_tokens = 20
                 }
             };
 
@@ -76,6 +85,12 @@ public class LlmServiceTests
         // Assert
         Assert.True(result.Success);
         Assert.Equal("Generated response", result.Response);
+        Assert.Equal(12, result.Usage.PromptTokens);
+        Assert.Equal(8, result.Usage.CompletionTokens);
+        Assert.Equal(20, result.Usage.TotalTokens);
+        Assert.Equal("anthropic/claude-3.5-sonnet", result.Metadata["model"]);
+        Assert.Equal("stop", result.Metadata["finish_reason"]);
+        Assert.Equal("resp_123", result.Metadata["response_id"]);
 
         var request = Assert.Single(handler.Requests);
         AssertRequestHeaders(request);

--- a/apps/api/tests/Api.Tests/QaEndpointTests.cs
+++ b/apps/api/tests/Api.Tests/QaEndpointTests.cs
@@ -1,5 +1,6 @@
 using Api.Infrastructure;
 using Api.Services;
+using System.Collections.Generic;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Http;
@@ -62,7 +63,10 @@ public class QaEndpointTests
         var llmServiceMock = new Mock<ILlmService>();
 
         // Configure LLM mock to return successful completion
-        var llmResult = LlmCompletionResult.CreateSuccess("Two players.");
+        var llmResult = LlmCompletionResult.CreateSuccess(
+            "Two players.",
+            new LlmUsage(6, 4, 10),
+            new Dictionary<string, string> { { "model", "anthropic/claude-3.5-sonnet" } });
         llmServiceMock
             .Setup(l => l.GenerateCompletionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(llmResult);
@@ -83,5 +87,8 @@ public class QaEndpointTests
         Assert.Single(response.snippets);
         Assert.Equal("Two players.", response.snippets[0].text);
         Assert.Equal("PDF:pdf-demo-chess", response.snippets[0].source);
+        Assert.Equal(6, response.promptTokens);
+        Assert.Equal(4, response.completionTokens);
+        Assert.Equal(10, response.totalTokens);
     }
 }

--- a/apps/api/tests/Api.Tests/RagServiceTests.cs
+++ b/apps/api/tests/Api.Tests/RagServiceTests.cs
@@ -1,6 +1,7 @@
 using Api.Infrastructure;
 using Api.Models;
 using Api.Services;
+using System.Collections.Generic;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -171,7 +172,10 @@ public class RagServiceTests
         var mockLlm = new Mock<ILlmService>();
         mockLlm
             .Setup(x => x.GenerateCompletionAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(LlmCompletionResult.CreateSuccess("This game supports 2-4 players."));
+            .ReturnsAsync(LlmCompletionResult.CreateSuccess(
+                "This game supports 2-4 players.",
+                new LlmUsage(12, 8, 20),
+                new Dictionary<string, string> { { "model", "anthropic/claude-3.5-sonnet" } }));
 
         var mockCache = new Mock<IAiResponseCacheService>();
         var ragService = new RagService(dbContext, mockEmbedding.Object, mockQdrant.Object, mockLlm.Object, mockCache.Object, _mockLogger.Object);
@@ -185,6 +189,10 @@ public class RagServiceTests
         Assert.Equal("This game supports 2-4 players.", result.snippets[0].text);
         Assert.Equal("PDF:pdf-1", result.snippets[0].source);
         Assert.Equal(1, result.snippets[0].page);
+        Assert.Equal(12, result.promptTokens);
+        Assert.Equal(8, result.completionTokens);
+        Assert.Equal(20, result.totalTokens);
+        Assert.NotNull(result.confidence);
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/SetupGuideServiceTests.cs
+++ b/apps/api/tests/Api.Tests/SetupGuideServiceTests.cs
@@ -153,6 +153,8 @@ public class SetupGuideServiceTests : IDisposable
         Assert.NotNull(result);
         Assert.Equal("Advanced Strategy Game", result.gameTitle);
         Assert.NotEmpty(result.steps);
+        Assert.NotNull(result.confidence);
+        Assert.Equal(0, result.totalTokens);
 
         // Verify steps have references from RAG
         var stepsWithReferences = result.steps.Where(s => s.references.Count > 0).ToList();

--- a/apps/web/src/pages/__tests__/admin.test.tsx
+++ b/apps/web/src/pages/__tests__/admin.test.tsx
@@ -109,12 +109,16 @@ describe('AdminDashboard', () => {
           responseSnippet: null,
           latencyMs: 210,
           tokenCount: 42,
+          promptTokens: 30,
+          completionTokens: 12,
           confidence: 0.8,
           status: 'Success',
           errorMessage: null,
           ipAddress: '127.0.0.1',
           userAgent: 'jest',
-          createdAt: '2024-01-01T12:00:00.000Z'
+          createdAt: '2024-01-01T12:00:00.000Z',
+          model: 'anthropic/claude-3.5-sonnet',
+          finishReason: 'stop'
         },
         {
           id: '2',
@@ -125,12 +129,16 @@ describe('AdminDashboard', () => {
           responseSnippet: null,
           latencyMs: 150,
           tokenCount: 18,
+          promptTokens: 10,
+          completionTokens: 8,
           confidence: 0.95,
           status: 'Success',
           errorMessage: null,
           ipAddress: '127.0.0.2',
           userAgent: 'jest',
-          createdAt: '2024-01-02T12:00:00.000Z'
+          createdAt: '2024-01-02T12:00:00.000Z',
+          model: 'anthropic/claude-3-haiku',
+          finishReason: 'length'
         }
       ]
     };
@@ -174,6 +182,9 @@ describe('AdminDashboard', () => {
 
     expect(screen.getByText('How do I win?')).toBeInTheDocument();
     expect(screen.getByText('Setup instructions')).toBeInTheDocument();
+    expect(screen.getByText('30')).toBeInTheDocument();
+    expect(screen.getByText('0.80')).toBeInTheDocument();
+    expect(screen.getByText('anthropic/claude-3.5-sonnet (stop)')).toBeInTheDocument();
 
     const user = userEvent.setup();
     const filterInput = screen.getByPlaceholderText(

--- a/apps/web/src/pages/admin.tsx
+++ b/apps/web/src/pages/admin.tsx
@@ -9,13 +9,17 @@ type AiRequest = {
   query: string | null;
   responseSnippet: string | null;
   latencyMs: number;
-  tokenCount: number | null;
+  tokenCount: number;
+  promptTokens: number;
+  completionTokens: number;
   confidence: number | null;
   status: string;
   errorMessage: string | null;
   ipAddress: string | null;
   userAgent: string | null;
   createdAt: string;
+  model: string | null;
+  finishReason: string | null;
 };
 
 type Stats = {
@@ -75,13 +79,32 @@ export default function AdminDashboard() {
   };
 
   const exportToCSV = () => {
-    const headers = ["Timestamp", "Endpoint", "Query", "Latency (ms)", "Tokens", "Status", "User ID", "Game ID"];
+    const headers = [
+      "Timestamp",
+      "Endpoint",
+      "Query",
+      "Latency (ms)",
+      "Total Tokens",
+      "Prompt Tokens",
+      "Completion Tokens",
+      "Confidence",
+      "Model",
+      "Finish Reason",
+      "Status",
+      "User ID",
+      "Game ID"
+    ];
     const rows = requests.map(req => [
       new Date(req.createdAt).toISOString(),
       req.endpoint,
       req.query || "",
       req.latencyMs.toString(),
-      req.tokenCount?.toString() || "",
+      req.tokenCount.toString(),
+      req.promptTokens.toString(),
+      req.completionTokens.toString(),
+      req.confidence !== null && req.confidence !== undefined ? req.confidence.toFixed(2) : "",
+      req.model || "",
+      req.finishReason || "",
       req.status,
       req.userId || "",
       req.gameId || ""
@@ -270,7 +293,7 @@ export default function AdminDashboard() {
             background: "#f8f9fa",
             borderBottom: "1px solid #dadce0",
             display: "grid",
-            gridTemplateColumns: "140px 80px 100px 80px 80px 1fr 100px",
+            gridTemplateColumns: "140px 80px 100px 80px 90px 110px 90px 100px 160px 1fr 100px",
             gap: 16,
             fontSize: 12,
             fontWeight: 600,
@@ -282,7 +305,11 @@ export default function AdminDashboard() {
           <div>Endpoint</div>
           <div>Game ID</div>
           <div>Latency</div>
-          <div>Tokens</div>
+          <div>Prompt</div>
+          <div>Completion</div>
+          <div>Total</div>
+          <div>Confidence</div>
+          <div>Model</div>
           <div>Query</div>
           <div>Status</div>
         </div>
@@ -299,7 +326,7 @@ export default function AdminDashboard() {
                 padding: 16,
                 borderBottom: "1px solid #f0f0f0",
                 display: "grid",
-                gridTemplateColumns: "140px 80px 100px 80px 80px 1fr 100px",
+                gridTemplateColumns: "140px 80px 100px 80px 90px 110px 90px 100px 160px 1fr 100px",
                 gap: 16,
                 fontSize: 13,
                 alignItems: "start"
@@ -322,7 +349,19 @@ export default function AdminDashboard() {
               </div>
               <div style={{ fontSize: 12, fontFamily: "monospace" }}>{req.latencyMs}ms</div>
               <div style={{ fontSize: 12, fontFamily: "monospace", color: "#5f6368" }}>
-                {req.tokenCount || "-"}
+                {req.promptTokens}
+              </div>
+              <div style={{ fontSize: 12, fontFamily: "monospace", color: "#5f6368" }}>
+                {req.completionTokens}
+              </div>
+              <div style={{ fontSize: 12, fontFamily: "monospace", color: "#5f6368" }}>
+                {req.tokenCount}
+              </div>
+              <div style={{ fontSize: 12, fontFamily: "monospace", color: "#5f6368" }}>
+                {req.confidence !== null && req.confidence !== undefined ? req.confidence.toFixed(2) : "-"}
+              </div>
+              <div style={{ fontSize: 12, color: "#5f6368" }}>
+                {req.model ? `${req.model}${req.finishReason ? ` (${req.finishReason})` : ""}` : "-"}
               </div>
               <div style={{ fontSize: 12, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                 {req.query || "-"}


### PR DESCRIPTION
## Summary
- extract token usage and metadata from OpenRouter responses and expose them through LlmCompletionResult
- persist prompt/completion token counts plus LLM metadata in ai_request_logs with a new migration
- surface token metrics, confidence, and model details in the admin dashboard along with updated unit tests

## Testing
- npm test -- --runTestsByPath src/pages/__tests__/admin.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e28445550483209978c6122271b37e