### PR TITLE
Fix Qdrant gRPC port configuration

### DIFF
--- a/apps/api/tests/Api.Tests/QdrantClientAdapterTests.cs
+++ b/apps/api/tests/Api.Tests/QdrantClientAdapterTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using Api.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Qdrant.Client;
+using Xunit;
+
+namespace Api.Tests;
+
+public class QdrantClientAdapterTests
+{
+    [Fact]
+    public void Constructor_UsesPortFromUrl_WhenProvided()
+    {
+        string? capturedHost = null;
+        int? capturedPort = null;
+        bool? capturedUseHttps = null;
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["QDRANT_URL"] = "http://example.com:7654"
+            })
+            .Build();
+
+        _ = new QdrantClientAdapter(
+            configuration,
+            NullLogger<QdrantClientAdapter>.Instance,
+            (host, port, useHttps) =>
+            {
+                capturedHost = host;
+                capturedPort = port;
+                capturedUseHttps = useHttps;
+                return new QdrantClient(host, port, useHttps);
+            });
+
+        Assert.Equal("example.com", capturedHost);
+        Assert.Equal(7654, capturedPort);
+        Assert.False(capturedUseHttps);
+    }
+
+    [Fact]
+    public void Constructor_UsesGrpcPortOverride_WhenProvided()
+    {
+        int? capturedPort = null;
+        bool? capturedUseHttps = null;
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["QDRANT_URL"] = "https://example.com",
+                ["QDRANT_GRPC_PORT"] = "7777"
+            })
+            .Build();
+
+        _ = new QdrantClientAdapter(
+            configuration,
+            NullLogger<QdrantClientAdapter>.Instance,
+            (_, port, useHttps) =>
+            {
+                capturedPort = port;
+                capturedUseHttps = useHttps;
+                return new QdrantClient("localhost", 1, false);
+            });
+
+        Assert.Equal(7777, capturedPort);
+        Assert.True(capturedUseHttps);
+    }
+
+    [Fact]
+    public void Constructor_DefaultsToGrpcPort_WhenRestPortUsed()
+    {
+        int? capturedPort = null;
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["QDRANT_URL"] = "http://example.com:6333"
+            })
+            .Build();
+
+        _ = new QdrantClientAdapter(
+            configuration,
+            NullLogger<QdrantClientAdapter>.Instance,
+            (_, port, _) =>
+            {
+                capturedPort = port;
+                return new QdrantClient("localhost", 1, false);
+            });
+
+        Assert.Equal(6334, capturedPort);
+    }
+}

--- a/docs/AI-01-embeddings-qdrant.md
+++ b/docs/AI-01-embeddings-qdrant.md
@@ -333,6 +333,9 @@ OPENROUTER_API_KEY=your-api-key-here
 
 # Qdrant connection (default: http://localhost:6333)
 QDRANT_URL=http://qdrant:6333
+# Optional: override gRPC port if Qdrant is exposed on a non-default port
+# (leave unset to use 6334 when QDRANT_URL points to the default HTTP port)
+# QDRANT_GRPC_PORT=6334
 ```
 
 **Optional**:
@@ -396,8 +399,9 @@ await qdrant.EnsureCollectionExistsAsync();
 ### Issue: Qdrant connection fails
 **Check**:
 1. Qdrant is running (`docker compose ps`)
-2. `QDRANT_URL` points to correct host
-3. Port 6334 (gRPC) is accessible
+2. `QDRANT_URL` points to correct host (and HTTPS if TLS is enabled)
+3. The gRPC port is accessible (defaults to 6334 when using the standard REST port,
+   or the value of `QDRANT_GRPC_PORT` when set)
 
 **Logs**:
 ```


### PR DESCRIPTION
## Summary
- derive the Qdrant gRPC connection settings from QDRANT_URL and allow explicit gRPC port overrides
- add adapter unit tests to cover the gRPC port selection logic
- document how to configure Qdrant host and gRPC port for the API

## Testing
- ⚠️ `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj` *(fails in container: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e2841da37c832092d43e13bef85b0d