### PR TITLE
feat: expose logs endpoint and fetch from web

### DIFF
--- a/apps/api/src/Api/Models/LogModels.cs
+++ b/apps/api/src/Api/Models/LogModels.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Api.Models;
+
+public record LogEntryResponse(
+    DateTime Timestamp,
+    string Level,
+    string Message,
+    string? RequestId,
+    string? UserId,
+    string? GameId
+);

--- a/apps/api/tests/Api.Tests/LogsEndpointTests.cs
+++ b/apps/api/tests/Api.Tests/LogsEndpointTests.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http.Json;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests;
+
+public class LogsEndpointTests : IClassFixture<WebApplicationFactoryFixture>
+{
+    private readonly WebApplicationFactoryFixture _factory;
+
+    public LogsEndpointTests(WebApplicationFactoryFixture factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task GetLogs_ReturnsLatestEntriesFromAiRequestLogService()
+    {
+        var now = DateTime.UtcNow;
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+            db.AiRequestLogs.AddRange(
+                new AiRequestLogEntity
+                {
+                    Id = "req-001",
+                    UserId = "user-123",
+                    GameId = "demo-chess",
+                    Endpoint = "qa",
+                    Query = "How many players?",
+                    ResponseSnippet = "Two players.",
+                    LatencyMs = 120,
+                    Status = "Success",
+                    CreatedAt = now.AddMinutes(-5)
+                },
+                new AiRequestLogEntity
+                {
+                    Id = "req-002",
+                    UserId = "user-456",
+                    GameId = "demo-chess",
+                    Endpoint = "qa",
+                    Query = "Explain setup",
+                    LatencyMs = 240,
+                    Status = "Error",
+                    ErrorMessage = "LLM timeout",
+                    CreatedAt = now
+                }
+            );
+
+            await db.SaveChangesAsync();
+        }
+
+        using var client = _factory.CreateClient();
+        var response = await client.GetAsync("/logs");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var entries = await response.Content.ReadFromJsonAsync<List<LogEntryResponse>>();
+
+        Assert.NotNull(entries);
+        Assert.Equal(2, entries!.Count);
+
+        var newest = entries[0];
+        Assert.Equal("req-002", newest.RequestId);
+        Assert.Equal("ERROR", newest.Level);
+        Assert.Equal("Explain setup", newest.Message);
+        Assert.Equal("user-456", newest.UserId);
+        Assert.Equal("demo-chess", newest.GameId);
+
+        var older = entries[1];
+        Assert.Equal("req-001", older.RequestId);
+        Assert.Equal("INFO", older.Level);
+        Assert.Equal("Two players.", older.Message);
+    }
+}

--- a/apps/web/src/pages/__tests__/logs.test.tsx
+++ b/apps/web/src/pages/__tests__/logs.test.tsx
@@ -1,14 +1,48 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import LogsPage from '../logs';
+import { api } from '../../lib/api';
+
+jest.mock('../../lib/api', () => ({
+  api: {
+    get: jest.fn()
+  }
+}));
 
 describe('LogsPage', () => {
+  const mockLogs = [
+    {
+      timestamp: new Date('2024-01-01T10:00:00Z').toISOString(),
+      level: 'INFO',
+      message: 'Application started',
+      requestId: 'req-001'
+    },
+    {
+      timestamp: new Date('2024-01-01T10:05:00Z').toISOString(),
+      level: 'INFO',
+      message: 'User logged in successfully',
+      requestId: 'req-002',
+      userId: 'user-123'
+    }
+  ];
+
+  const mockGet = api.get as jest.MockedFunction<typeof api.get>;
+
+  beforeEach(() => {
+    mockGet.mockResolvedValue(mockLogs);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders default logs and allows filtering by user id', async () => {
     const user = userEvent.setup();
 
     render(<LogsPage />);
 
     await screen.findByText(/Application started/i);
+    expect(mockGet).toHaveBeenCalledWith('/logs');
     expect(screen.getByText(/User logged in successfully/i)).toBeInTheDocument();
 
     const filterInput = screen.getByPlaceholderText(/Filter logs/i);


### PR DESCRIPTION
## Summary
- add a minimal log entry DTO and expose GET /logs backed by AI request logs
- update the logs dashboard to fetch data from the API with loading and error states
- cover the new flow with a dedicated integration test and refreshed Jest coverage

## Testing
- npm test -- --runTestsByPath src/pages/__tests__/logs.test.tsx
- dotnet test --filter LogsEndpointTests *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e28433ebd083208629712eb2584abc