### PR TITLE
feat: generate rulespec from ingested pdf

### DIFF
--- a/apps/api/src/Api/Services/RuleSpecService.cs
+++ b/apps/api/src/Api/Services/RuleSpecService.cs
@@ -3,6 +3,8 @@ using Api.Infrastructure.Entities;
 using Api.Models;
 using Microsoft.EntityFrameworkCore;
 using System.Globalization;
+using System.Text.Json;
+using System.Text.RegularExpressions;
 
 namespace Api.Services;
 
@@ -83,6 +85,40 @@ public class RuleSpecService
             .FirstOrDefaultAsync(cancellationToken);
 
         return specEntity is null ? null : ToModel(specEntity);
+    }
+
+    public async Task<RuleSpec> GenerateRuleSpecFromPdfAsync(string pdfId, CancellationToken cancellationToken = default)
+    {
+        var pdf = await _dbContext.PdfDocuments
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Id == pdfId, cancellationToken);
+
+        if (pdf is null)
+        {
+            throw new KeyNotFoundException($"PDF document {pdfId} not found");
+        }
+
+        if (!string.Equals(pdf.ProcessingStatus, "completed", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("PDF is not ready yet. Please wait for processing to complete.");
+        }
+
+        var atoms = ParseAtomicRules(pdf.AtomicRules);
+
+        if (atoms.Count == 0)
+        {
+            atoms.AddRange(ParseExtractedText(pdf.ExtractedText));
+        }
+
+        if (atoms.Count == 0)
+        {
+            throw new InvalidOperationException("No extracted rules available for this PDF");
+        }
+
+        var processedAt = pdf.ProcessedAt ?? DateTime.UtcNow;
+        var version = $"pdf-{processedAt:yyyyMMddHHmmss}";
+
+        return new RuleSpec(pdf.GameId, version, processedAt, atoms);
     }
 
     public async Task<RuleSpec> UpdateRuleSpecAsync(string gameId, RuleSpec ruleSpec, CancellationToken cancellationToken = default)
@@ -166,5 +202,113 @@ public class RuleSpecService
             .ToList();
 
         return new RuleSpec(entity.GameId, entity.Version, entity.CreatedAt, atoms);
+    }
+
+    private static List<RuleAtom> ParseAtomicRules(string? atomicRulesJson)
+    {
+        var atoms = new List<RuleAtom>();
+
+        if (string.IsNullOrWhiteSpace(atomicRulesJson))
+        {
+            return atoms;
+        }
+
+        List<string>? atomicRules;
+        try
+        {
+            atomicRules = JsonSerializer.Deserialize<List<string>>(atomicRulesJson);
+        }
+        catch (JsonException)
+        {
+            return atoms;
+        }
+
+        if (atomicRules is null)
+        {
+            return atoms;
+        }
+
+        int index = 1;
+        foreach (var ruleText in atomicRules)
+        {
+            if (string.IsNullOrWhiteSpace(ruleText))
+            {
+                continue;
+            }
+
+            var text = ruleText.Trim();
+            string? page = null;
+            string? section = null;
+
+            var match = Regex.Match(text, @"\[Table on page\s+(?<page>\d+)\]", RegexOptions.IgnoreCase);
+            if (match.Success)
+            {
+                page = match.Groups["page"].Value;
+                section = "Table";
+                text = text.Substring(match.Index + match.Length).Trim();
+            }
+
+            if (text.StartsWith(':'))
+            {
+                text = text.TrimStart(':').Trim();
+            }
+
+            if (text.Length == 0)
+            {
+                continue;
+            }
+
+            text = NormalizeWhitespace(text);
+
+            atoms.Add(new RuleAtom($"atom-{index}", text, section, page, null));
+            index++;
+        }
+
+        return atoms;
+    }
+
+    private static List<RuleAtom> ParseExtractedText(string? extractedText)
+    {
+        var atoms = new List<RuleAtom>();
+
+        if (string.IsNullOrWhiteSpace(extractedText))
+        {
+            return atoms;
+        }
+
+        var segments = SplitIntoSegments(extractedText);
+
+        int index = 1;
+        foreach (var segment in segments)
+        {
+            var text = NormalizeWhitespace(segment);
+            if (text.Length == 0)
+            {
+                continue;
+            }
+
+            atoms.Add(new RuleAtom($"atom-{index}", text));
+            index++;
+        }
+
+        return atoms;
+    }
+
+    private static IEnumerable<string> SplitIntoSegments(string text)
+    {
+        var paragraphSeparators = new[] { "\r\n\r\n", "\n\n" };
+        var segments = text.Split(paragraphSeparators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        if (segments.Length <= 1)
+        {
+            segments = text.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        }
+
+        return segments.Where(s => !string.IsNullOrWhiteSpace(s));
+    }
+
+    private static string NormalizeWhitespace(string text)
+    {
+        return Regex.Replace(text, @"\s+", " ").Trim();
     }
 }


### PR DESCRIPTION
## Summary
- extend RuleSpecService with PDF parsing helpers and expose POST /ingest/pdf/{pdfId}/rulespec
- update API and service tests to cover PDF-driven RuleSpec generation and endpoint behavior
- hook the upload wizard to the new endpoint and adjust frontend tests for the real parsing flow

## Testing
- npm test -- --runTestsByPath src/pages/__tests__/upload.test.tsx
- dotnet test *(fails locally: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e28439276c832086e71d15a1eae324