### PR TITLE
feat: add PDF processing polling to upload wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,22 @@ scripts/, tools/, schemas/ ...
 
 Per altre linee guida consulta `agents.md` e i README specifici nelle rispettive app.
 
+## PDF Import Wizard
+
+L'interfaccia `PDF Import Wizard` (pagina `/upload`) guida l'utente attraverso l'ingestione di un nuovo regolamento in tre
+passaggi:
+
+1. **Upload** – Seleziona o crea un gioco, quindi carica il PDF. Il backend restituisce un `documentId` che identifica
+   l'elaborazione asincrona del file.
+2. **Parse** – Il frontend interroga automaticamente l'endpoint `/pdfs/{documentId}/text` ogni 2 secondi e mostra una barra di
+   avanzamento dello stato (`pending → processing → completed/failed`). Finché lo stato non è `completed` il pulsante di
+   parsing resta disabilitato; al completamento, il wizard carica la `RuleSpec` reale del gioco e prosegue da solo alla fase di
+   review. Eventuali errori (`failed` o problemi di polling) vengono mostrati direttamente nella UI.
+3. **Review & Publish** – Una volta caricata la `RuleSpec`, l'utente può modificare gli `RuleAtom`, pubblicare le modifiche o
+   tornare indietro.
+
+In caso di errore di parsing è possibile riavviare il flusso con **Start Over** e ripetere l'upload.
+
 ## Contribuire
 
 Accogliamo contributi dalla community! Prima di iniziare:


### PR DESCRIPTION
## Summary
- add client-side polling of `/pdfs/{documentId}/text` with progress, auto-advance, and error handling in the upload wizard
- cover the new workflow with a component test that mocks fetch responses for upload, polling, and RuleSpec loading
- document the updated PDF Import Wizard flow for end users

## Testing
- npm test -- --runTestsByPath src/pages/__tests__/upload.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e2843a562483208c620e24f88fea3d