### PR TITLE
Fix AI request logging cancellation token parameter order

### DIFF
--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -415,13 +415,11 @@ app.MapPost("/agents/qa", async (QaRequest req, HttpContext context, RagService 
             req.query,
             null,
             latencyMs,
-            null,
-            null,
-            "Error",
-            ex.Message,
-            context.Connection.RemoteIpAddress?.ToString(),
-            context.Request.Headers.UserAgent.ToString(),
-            ct);
+            status: "Error",
+            errorMessage: ex.Message,
+            ipAddress: context.Connection.RemoteIpAddress?.ToString(),
+            userAgent: context.Request.Headers.UserAgent.ToString(),
+            ct: ct);
 
         throw;
     }
@@ -485,13 +483,11 @@ app.MapPost("/agents/explain", async (ExplainRequest req, HttpContext context, R
             req.topic,
             null,
             latencyMs,
-            null,
-            null,
-            "Error",
-            ex.Message,
-            context.Connection.RemoteIpAddress?.ToString(),
-            context.Request.Headers.UserAgent.ToString(),
-            ct);
+            status: "Error",
+            errorMessage: ex.Message,
+            ipAddress: context.Connection.RemoteIpAddress?.ToString(),
+            userAgent: context.Request.Headers.UserAgent.ToString(),
+            ct: ct);
 
         throw;
     }
@@ -564,13 +560,11 @@ app.MapPost("/agents/setup", async (SetupGuideRequest req, HttpContext context, 
             "setup_guide",
             null,
             latencyMs,
-            null,
-            null,
-            "Error",
-            ex.Message,
-            context.Connection.RemoteIpAddress?.ToString(),
-            context.Request.Headers.UserAgent.ToString(),
-            ct);
+            status: "Error",
+            errorMessage: ex.Message,
+            ipAddress: context.Connection.RemoteIpAddress?.ToString(),
+            userAgent: context.Request.Headers.UserAgent.ToString(),
+            ct: ct);
 
         throw;
     }


### PR DESCRIPTION
## Summary
- use named optional arguments when logging failed AI requests so the cancellation token binds correctly

## Testing
- dotnet build *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e29d487db48320b461d46ee8014060