### PR TITLE
fix: use named arguments when logging ai requests

### DIFF
--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -395,11 +395,11 @@ app.MapPost("/agents/qa", async (QaRequest req, HttpContext context, RagService 
             null,
             context.Connection.RemoteIpAddress?.ToString(),
             context.Request.Headers.UserAgent.ToString(),
-            resp.promptTokens,
-            resp.completionTokens,
-            model,
-            finishReason,
-            ct);
+            promptTokens: resp.promptTokens,
+            completionTokens: resp.completionTokens,
+            model: model,
+            finishReason: finishReason,
+            ct: ct);
 
         return Results.Json(resp);
     }
@@ -463,11 +463,11 @@ app.MapPost("/agents/explain", async (ExplainRequest req, HttpContext context, R
             null,
             context.Connection.RemoteIpAddress?.ToString(),
             context.Request.Headers.UserAgent.ToString(),
-            resp.promptTokens,
-            resp.completionTokens,
-            null,
-            null,
-            ct);
+            promptTokens: resp.promptTokens,
+            completionTokens: resp.completionTokens,
+            model: null,
+            finishReason: null,
+            ct: ct);
 
         return Results.Json(resp);
     }
@@ -540,11 +540,11 @@ app.MapPost("/agents/setup", async (SetupGuideRequest req, HttpContext context, 
             null,
             context.Connection.RemoteIpAddress?.ToString(),
             context.Request.Headers.UserAgent.ToString(),
-            resp.promptTokens,
-            resp.completionTokens,
-            null,
-            null,
-            ct);
+            promptTokens: resp.promptTokens,
+            completionTokens: resp.completionTokens,
+            model: null,
+            finishReason: null,
+            ct: ct);
 
         return Results.Json(resp);
     }


### PR DESCRIPTION
## Summary
- use named arguments when logging AI requests so the optional parameters bind correctly after adding prompt/completion token logging

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e29edbf89083208f80d88829d89f1f