### PR TITLE
Fix PdfStorageServiceTests helper parameter handling

### DIFF
--- a/apps/api/tests/Api.Tests/PdfStorageServiceTests.cs
+++ b/apps/api/tests/Api.Tests/PdfStorageServiceTests.cs
@@ -37,7 +37,7 @@ public class PdfStorageServiceTests
         string storagePath,
         Mock<IBackgroundTaskService> backgroundTaskMock,
         Mock<IServiceScopeFactory>? scopeFactoryMock = null,
-        Mock<IAiResponseCacheService>? cacheMock = null)
+        Mock<IAiResponseCacheService>? cacheMock = null,
         PdfTextExtractionService? textExtractionService = null,
         PdfTableExtractionService? tableExtractionService = null,
         ITextChunkingService? textChunkingService = null,
@@ -62,13 +62,10 @@ public class PdfStorageServiceTests
             scopeFactoryMock.Object,
             configurationMock.Object,
             loggerMock.Object,
-            textExtractionService,
-            tableExtractionService,
-            backgroundTaskMock.Object,
-            cacheMock.Object);
             textExtractionService ?? new PdfTextExtractionService(Mock.Of<ILogger<PdfTextExtractionService>>()),
             tableExtractionService ?? new PdfTableExtractionService(Mock.Of<ILogger<PdfTableExtractionService>>()),
             backgroundTaskMock.Object,
+            cacheMock.Object,
             textChunkingService,
             embeddingService,
             qdrantService);


### PR DESCRIPTION
## Summary
- keep optional PdfStorageService dependencies inside the CreateService helper signature
- pass fallback instances for optional dependencies when constructing PdfStorageService

## Testing
- `dotnet build` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a2433314832092f128dc6d03503e