### PR TITLE
Fix optional dependency handling in PdfStorageService tests

### DIFF
--- a/apps/api/tests/Api.Tests/PdfStorageServiceTests.cs
+++ b/apps/api/tests/Api.Tests/PdfStorageServiceTests.cs
@@ -374,11 +374,11 @@ public class PdfStorageServiceTests
                 storagePath,
                 backgroundMock,
                 scopeFactoryMock,
-                textExtractionMock.Object,
-                tableExtractionMock.Object,
-                chunkingMock.Object,
-                embeddingMock.Object,
-                qdrantMock.Object);
+                textExtractionService: textExtractionMock.Object,
+                tableExtractionService: tableExtractionMock.Object,
+                textChunkingService: chunkingMock.Object,
+                embeddingService: embeddingMock.Object,
+                qdrantService: qdrantMock.Object);
 
             var file = CreateFormFile("rules.pdf", "application/pdf", new byte[] { 1, 2, 3, 4 });
             var uploadResult = await service.UploadPdfAsync("game-1", "user", file, CancellationToken.None);


### PR DESCRIPTION
## Summary
- update PdfStorageService test helper to keep optional dependency parameters after the cache mock
- pass override services using named parameters so the helper can be called without a cache mock

## Testing
- dotnet build *(fails: `dotnet` CLI is unavailable in the execution environment)*
- dotnet test *(fails: `dotnet` CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a93491e883209fbe8b04692918a2