### PR TITLE
Fix PdfStorageService override test dependency ordering

### DIFF
--- a/apps/api/tests/Api.Tests/PdfStorageServiceTests.cs
+++ b/apps/api/tests/Api.Tests/PdfStorageServiceTests.cs
@@ -304,6 +304,8 @@ public class PdfStorageServiceTests
             scopeMock.Setup(s => s.Dispose());
             scopeFactoryMock.Setup(s => s.CreateScope()).Returns(scopeMock.Object);
 
+            var cacheMock = new Mock<IAiResponseCacheService>();
+
             var textExtractionMock = new Mock<PdfTextExtractionService>(
                 MockBehavior.Strict,
                 Mock.Of<ILogger<PdfTextExtractionService>>());
@@ -374,6 +376,7 @@ public class PdfStorageServiceTests
                 storagePath,
                 backgroundMock,
                 scopeFactoryMock,
+                cacheMock,
                 textExtractionMock.Object,
                 tableExtractionMock.Object,
                 chunkingMock.Object,


### PR DESCRIPTION
## Summary
- update the PdfStorageService helper usage in IndexVectorsAsync_UsesOverridesWhenProvided so optional overrides align with the helper signature
- inject a cache mock before the other overrides to keep extraction/table services in the expected parameters

## Testing
- dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a94467f08320a7e4d6fe6e4d4178