### PR TITLE
Improve PDF table column detection from character positions

### DIFF
--- a/apps/api/src/Api/Services/PdfTableExtractionService.cs
+++ b/apps/api/src/Api/Services/PdfTableExtractionService.cs
@@ -1,8 +1,10 @@
+using iText.Kernel.Geom;
 using iText.Kernel.Pdf;
 using iText.Kernel.Pdf.Canvas.Parser;
-using iText.Kernel.Pdf.Canvas.Parser.Listener;
 using iText.Kernel.Pdf.Canvas.Parser.Data;
+using iText.Kernel.Pdf.Canvas.Parser.Listener;
 using System.Text;
+using System.Linq;
 
 namespace Api.Services;
 
@@ -65,12 +67,9 @@ public class PdfTableExtractionService
         {
             var page = pdfDoc.GetPage(pageNum);
 
-            // Extract text with location information
-            var strategy = new LocationTextExtractionStrategy();
-            var pageText = PdfTextExtractor.GetTextFromPage(page, strategy);
-
             // Analyze page for table-like structures
-            var pageTables = DetectTablesInPage(pageText, pageNum);
+            var pageLines = ExtractPageLines(page);
+            var pageTables = DetectTablesInPage(pageLines, pageNum);
             tables.AddRange(pageTables);
 
             // Convert table rows to atomic rules
@@ -96,87 +95,219 @@ public class PdfTableExtractionService
     /// Detects table-like structures in page text
     /// Uses heuristics to identify structured data patterns
     /// </summary>
-    private List<PdfTable> DetectTablesInPage(string pageText, int pageNum)
+    private List<PdfTable> DetectTablesInPage(List<PositionedTextLine> lines, int pageNum)
     {
         var tables = new List<PdfTable>();
 
-        if (string.IsNullOrWhiteSpace(pageText))
+        if (lines.Count == 0)
         {
             return tables;
         }
 
-        var lines = pageText.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var currentRows = new List<string[]>();
+        List<ColumnBoundary>? currentBoundaries = null;
+        var tableStartLine = -1;
 
-        // Simple table detection: look for lines with multiple tab-separated or space-separated values
-        var currentTable = new List<string[]>();
-        var isInTable = false;
-
-        for (int i = 0; i < lines.Length; i++)
+        for (int i = 0; i < lines.Count; i++)
         {
-            var line = lines[i].Trim();
+            var line = lines[i];
+            var trimmedText = line.GetTrimmedText();
 
-            // Skip empty lines
-            if (string.IsNullOrWhiteSpace(line))
+            if (string.IsNullOrWhiteSpace(trimmedText))
             {
-                if (isInTable && currentTable.Count > 1)
-                {
-                    // End of table detected
-                    tables.Add(CreateTableFromRows(currentTable, pageNum, i - currentTable.Count + 1));
-                    currentTable.Clear();
-                    isInTable = false;
-                }
+                FinalizeCurrentTable();
                 continue;
             }
 
-            // Detect potential table row (contains multiple columns)
-            // Heuristic: line with multiple spaces suggesting column separation
-            var columns = SplitIntoColumns(line);
+            if (currentBoundaries == null)
+            {
+                var split = SplitIntoColumns(line, null);
 
-            if (columns.Length >= 2)
-            {
-                currentTable.Add(columns);
-                isInTable = true;
+                if (split.Columns.Count >= 2)
+                {
+                    currentBoundaries = split.Boundaries;
+                    tableStartLine = i;
+                    currentRows.Add(NormalizeRow(split.Columns, currentBoundaries.Count));
+                }
+                else
+                {
+                    FinalizeCurrentTable();
+                }
             }
-            else if (isInTable && currentTable.Count > 1)
+            else
             {
-                // End of table
-                tables.Add(CreateTableFromRows(currentTable, pageNum, i - currentTable.Count));
-                currentTable.Clear();
-                isInTable = false;
+                var split = SplitIntoColumns(line, currentBoundaries);
+                var boundariesForRow = split.Boundaries;
+                var columnCount = boundariesForRow.Count;
+
+                if (columnCount > currentBoundaries.Count)
+                {
+                    for (int r = 0; r < currentRows.Count; r++)
+                    {
+                        currentRows[r] = NormalizeRow(currentRows[r], columnCount);
+                    }
+                }
+
+                currentBoundaries = boundariesForRow;
+
+                var normalizedRow = NormalizeRow(split.Columns, columnCount);
+                var hasContent = normalizedRow.Any(value => !string.IsNullOrWhiteSpace(value));
+
+                if (hasContent)
+                {
+                    currentRows.Add(normalizedRow);
+                }
+                else
+                {
+                    FinalizeCurrentTable();
+                }
             }
         }
 
-        // Handle table that ends at page end
-        if (currentTable.Count > 1)
-        {
-            tables.Add(CreateTableFromRows(currentTable, pageNum, lines.Length - currentTable.Count));
-        }
+        FinalizeCurrentTable();
 
         return tables;
+
+        void FinalizeCurrentTable()
+        {
+            if (currentRows.Count > 1 && currentBoundaries != null)
+            {
+                tables.Add(CreateTableFromRows(
+                    currentRows,
+                    pageNum,
+                    tableStartLine >= 0 ? tableStartLine : 0,
+                    currentBoundaries.Count));
+            }
+
+            currentRows.Clear();
+            currentBoundaries = null;
+            tableStartLine = -1;
+        }
     }
 
     /// <summary>
-    /// Splits a line into columns based on spacing patterns
+    /// Splits a line into columns based on character positioning
     /// </summary>
-    private string[] SplitIntoColumns(string line)
+    private ColumnSplitResult SplitIntoColumns(PositionedTextLine line, List<ColumnBoundary>? existingBoundaries)
     {
-        // Split by 2+ spaces or tabs as column separators
-        var columns = System.Text.RegularExpressions.Regex
-            .Split(line, @"\s{2,}|\t+")
-            .Where(c => !string.IsNullOrWhiteSpace(c))
-            .Select(c => c.Trim())
-            .ToArray();
+        var result = new ColumnSplitResult();
 
-        return columns;
+        if (line.Characters.Count == 0)
+        {
+            if (existingBoundaries != null)
+            {
+                result.Boundaries = existingBoundaries;
+                result.Columns = Enumerable.Repeat(string.Empty, existingBoundaries.Count).ToList();
+            }
+
+            return result;
+        }
+
+        var boundaries = existingBoundaries != null && existingBoundaries.Count > 0
+            ? existingBoundaries.Select(b => b.Clone()).ToList()
+            : DetectColumnBoundaries(line);
+
+        if (boundaries.Count == 0)
+        {
+            var text = line.GetTrimmedText();
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                result.Columns.Add(text);
+            }
+
+            return result;
+        }
+
+        boundaries = boundaries
+            .OrderBy(b => b.Start)
+            .ToList();
+
+        var tolerance = Math.Max(2f, line.GetAverageCharacterWidth() * 0.75f);
+        var columnTexts = boundaries.Select(_ => new StringBuilder()).ToList();
+
+        foreach (var character in line.Characters)
+        {
+            var columnIndex = FindBoundaryIndex(boundaries, character, tolerance);
+
+            if (columnIndex == -1)
+            {
+                var newBoundary = new ColumnBoundary
+                {
+                    Start = character.X - tolerance,
+                    End = character.EndX + tolerance
+                };
+
+                var insertIndex = boundaries.FindIndex(b => newBoundary.Start < b.Start);
+                if (insertIndex < 0)
+                {
+                    boundaries.Add(newBoundary);
+                    columnTexts.Add(new StringBuilder());
+                    columnIndex = boundaries.Count - 1;
+                }
+                else
+                {
+                    boundaries.Insert(insertIndex, newBoundary);
+                    columnTexts.Insert(insertIndex, new StringBuilder());
+                    columnIndex = insertIndex;
+                }
+            }
+
+            var boundary = boundaries[columnIndex];
+            boundary.Start = Math.Min(boundary.Start, character.X - tolerance);
+            boundary.End = Math.Max(boundary.End, character.EndX + tolerance);
+            columnTexts[columnIndex].Append(character.Text);
+        }
+
+        result.Boundaries = boundaries;
+        result.Columns = columnTexts.Select(sb => sb.ToString().Trim()).ToList();
+
+        return result;
+    }
+
+    private int FindBoundaryIndex(List<ColumnBoundary> boundaries, PositionedCharacter character, float tolerance)
+    {
+        var center = character.CenterX;
+
+        for (int i = 0; i < boundaries.Count; i++)
+        {
+            var boundary = boundaries[i];
+            if (center >= boundary.Start - tolerance && center <= boundary.End + tolerance)
+            {
+                return i;
+            }
+        }
+
+        var closestIndex = -1;
+        var closestDistance = float.MaxValue;
+
+        for (int i = 0; i < boundaries.Count; i++)
+        {
+            var boundary = boundaries[i];
+            var distance = Math.Min(Math.Abs(center - boundary.Start), Math.Abs(center - boundary.End));
+
+            if (distance < closestDistance)
+            {
+                closestDistance = distance;
+                closestIndex = i;
+            }
+        }
+
+        if (closestDistance <= tolerance * 2)
+        {
+            return closestIndex;
+        }
+
+        return -1;
     }
 
     /// <summary>
     /// Creates a PdfTable object from detected rows
     /// </summary>
-    private PdfTable CreateTableFromRows(List<string[]> rows, int pageNum, int startLine)
+    private PdfTable CreateTableFromRows(List<string[]> rows, int pageNum, int startLine, int columnCount)
     {
-        var headers = rows.Count > 0 ? rows[0] : Array.Empty<string>();
-        var dataRows = rows.Count > 1 ? rows.Skip(1).ToList() : new List<string[]>();
+        var normalizedRows = rows.Select(row => NormalizeRow(row, columnCount)).ToList();
+        var headers = normalizedRows.Count > 0 ? normalizedRows[0] : new string[columnCount];
+        var dataRows = normalizedRows.Count > 1 ? normalizedRows.Skip(1).ToList() : new List<string[]>();
 
         return new PdfTable
         {
@@ -184,9 +315,270 @@ public class PdfTableExtractionService
             StartLine = startLine,
             Headers = headers.ToList(),
             Rows = dataRows,
-            ColumnCount = headers.Length,
+            ColumnCount = columnCount,
             RowCount = dataRows.Count
         };
+    }
+
+    private string[] NormalizeRow(IReadOnlyList<string> columns, int columnCount)
+    {
+        var normalized = new string[columnCount];
+
+        for (int i = 0; i < columnCount; i++)
+        {
+            normalized[i] = i < columns.Count ? columns[i].Trim() : string.Empty;
+        }
+
+        return normalized;
+    }
+
+    private List<ColumnBoundary> DetectColumnBoundaries(PositionedTextLine line)
+    {
+        var boundaries = new List<ColumnBoundary>();
+
+        if (line.Characters.Count == 0)
+        {
+            return boundaries;
+        }
+
+        var threshold = CalculateGapThreshold(line);
+        ColumnBoundary? current = null;
+
+        foreach (var character in line.Characters)
+        {
+            if (current == null)
+            {
+                current = new ColumnBoundary
+                {
+                    Start = character.X,
+                    End = character.EndX
+                };
+                continue;
+            }
+
+            var gap = character.X - current.End;
+
+            if (gap > threshold)
+            {
+                boundaries.Add(current);
+                current = new ColumnBoundary
+                {
+                    Start = character.X,
+                    End = character.EndX
+                };
+            }
+            else
+            {
+                current.End = Math.Max(current.End, character.EndX);
+            }
+        }
+
+        if (current != null)
+        {
+            boundaries.Add(current);
+        }
+
+        var padding = Math.Max(2f, threshold / 3f);
+
+        foreach (var boundary in boundaries)
+        {
+            boundary.Start -= padding;
+            boundary.End += padding;
+        }
+
+        return boundaries;
+    }
+
+    private float CalculateGapThreshold(PositionedTextLine line)
+    {
+        if (line.Characters.Count < 2)
+        {
+            return Math.Max(6f, line.GetAverageCharacterWidth() * 2.5f);
+        }
+
+        var gaps = new List<float>();
+
+        for (int i = 1; i < line.Characters.Count; i++)
+        {
+            var previous = line.Characters[i - 1];
+            var current = line.Characters[i];
+            var gap = current.X - previous.EndX;
+
+            if (gap > 0)
+            {
+                gaps.Add(gap);
+            }
+        }
+
+        if (gaps.Count == 0)
+        {
+            return Math.Max(6f, line.GetAverageCharacterWidth() * 2.5f);
+        }
+
+        gaps.Sort();
+        var median = gaps[gaps.Count / 2];
+        var averageWidth = line.GetAverageCharacterWidth();
+        var baseline = averageWidth > 0 ? averageWidth * 2f : 6f;
+
+        return Math.Max(median * 1.8f, Math.Max(6f, baseline));
+    }
+
+    private List<PositionedTextLine> ExtractPageLines(PdfPage page)
+    {
+        var strategy = new PositionedTextExtractionStrategy();
+        var processor = new PdfCanvasProcessor(strategy);
+        processor.ProcessPageContent(page);
+        return strategy.GetLines();
+    }
+
+    private sealed class ColumnSplitResult
+    {
+        public List<string> Columns { get; set; } = new();
+        public List<ColumnBoundary> Boundaries { get; set; } = new();
+    }
+
+    private sealed class ColumnBoundary
+    {
+        public float Start { get; set; }
+        public float End { get; set; }
+
+        public float Center => (Start + End) / 2f;
+
+        public ColumnBoundary Clone() => new()
+        {
+            Start = Start,
+            End = End
+        };
+    }
+
+    private sealed class PositionedCharacter
+    {
+        public PositionedCharacter(string text, float x, float y, float width)
+        {
+            Text = text;
+            X = x;
+            Y = y;
+            Width = width;
+        }
+
+        public string Text { get; }
+        public float X { get; }
+        public float Y { get; }
+        public float Width { get; }
+        public float EndX => X + Width;
+        public float CenterX => X + Width / 2f;
+    }
+
+    private sealed class PositionedTextLine
+    {
+        private readonly List<PositionedCharacter> _characters = new();
+
+        public PositionedTextLine(float y)
+        {
+            Y = y;
+        }
+
+        public float Y { get; }
+
+        public IReadOnlyList<PositionedCharacter> Characters => _characters;
+
+        public void AddCharacter(PositionedCharacter character) => _characters.Add(character);
+
+        public void SortCharacters() => _characters.Sort((a, b) => a.X.CompareTo(b.X));
+
+        public string GetText() => string.Concat(_characters.Select(c => c.Text));
+
+        public string GetTrimmedText() => GetText().Trim();
+
+        public float GetAverageCharacterWidth()
+        {
+            var widths = _characters
+                .Select(c => c.Width)
+                .Where(w => w > 0)
+                .ToList();
+
+            if (widths.Count == 0)
+            {
+                return 0f;
+            }
+
+            return widths.Sum() / widths.Count;
+        }
+    }
+
+    private sealed class PositionedTextExtractionStrategy : IEventListener
+    {
+        private readonly List<PositionedCharacter> _characters = new();
+
+        public void EventOccurred(IEventData data, EventType type)
+        {
+            if (type != EventType.RENDER_TEXT)
+            {
+                return;
+            }
+
+            if (data is TextRenderInfo renderInfo)
+            {
+                foreach (var characterInfo in renderInfo.GetCharacterRenderInfos())
+                {
+                    var text = characterInfo.GetText();
+
+                    if (string.IsNullOrEmpty(text))
+                    {
+                        continue;
+                    }
+
+                    var baseline = characterInfo.GetBaseline();
+                    var startPoint = baseline.GetStartPoint();
+                    var endPoint = baseline.GetEndPoint();
+                    var x = (float)startPoint.Get(Vector.I1);
+                    var y = (float)startPoint.Get(Vector.I2);
+                    var width = (float)Math.Abs(endPoint.Get(Vector.I1) - startPoint.Get(Vector.I1));
+
+                    if (width <= 0)
+                    {
+                        width = characterInfo.GetSingleSpaceWidth();
+                    }
+
+                    _characters.Add(new PositionedCharacter(text, x, y, width));
+                }
+            }
+        }
+
+        public ICollection<EventType> GetSupportedEvents() => new HashSet<EventType> { EventType.RENDER_TEXT };
+
+        public List<PositionedTextLine> GetLines()
+        {
+            const float yTolerance = 2.5f;
+
+            var orderedCharacters = _characters
+                .OrderByDescending(c => c.Y)
+                .ToList();
+
+            var lines = new List<PositionedTextLine>();
+
+            foreach (var character in orderedCharacters)
+            {
+                var line = lines.FirstOrDefault(existing => Math.Abs(existing.Y - character.Y) <= yTolerance);
+
+                if (line == null)
+                {
+                    line = new PositionedTextLine(character.Y);
+                    lines.Add(line);
+                }
+
+                line.AddCharacter(character);
+            }
+
+            foreach (var line in lines)
+            {
+                line.SortCharacters();
+            }
+
+            lines.Sort((a, b) => b.Y.CompareTo(a.Y));
+
+            return lines;
+        }
     }
 
     /// <summary>

--- a/apps/api/tests/Api.Tests/PdfTableExtractionServiceTests.cs
+++ b/apps/api/tests/Api.Tests/PdfTableExtractionServiceTests.cs
@@ -1,20 +1,101 @@
 using Api.Services;
 using Microsoft.Extensions.Logging;
 using Moq;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+using System.Linq;
 using Xunit;
 
 namespace Api.Tests;
 
-public class PdfTableExtractionServiceTests
+public class PdfTableExtractionServiceTests : IDisposable
 {
     private readonly Mock<ILogger<PdfTableExtractionService>> _mockLogger;
     private readonly PdfTableExtractionService _service;
+    private readonly List<string> _tempFiles = new();
 
     public PdfTableExtractionServiceTests()
     {
+        QuestPDF.Settings.License = LicenseType.Community;
         _mockLogger = new Mock<ILogger<PdfTableExtractionService>>();
         _service = new PdfTableExtractionService(_mockLogger.Object);
     }
+
+    public void Dispose()
+    {
+        foreach (var file in _tempFiles)
+        {
+            try
+            {
+                if (File.Exists(file))
+                {
+                    File.Delete(file);
+                }
+            }
+            catch
+            {
+                // Ignore cleanup failures in tests
+            }
+        }
+    }
+
+    private string CreateTempPdfPath()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"structured_{Guid.NewGuid():N}.pdf");
+        _tempFiles.Add(path);
+        return path;
+    }
+
+    private void CreateStructuredPdf(string filePath)
+    {
+        Document.Create(container =>
+        {
+            container.Page(page =>
+            {
+                page.Size(PageSizes.A4);
+                page.Margin(2, Unit.Centimetre);
+                page.Content().Column(column =>
+                {
+                    column.Spacing(10);
+                    column.Item().Text(text =>
+                    {
+                        text.Span("Structured Table Fixture").SemiBold().FontSize(18);
+                    });
+
+                    column.Item().Table(table =>
+                    {
+                        table.ColumnsDefinition(columns =>
+                        {
+                            columns.RelativeColumn();
+                            columns.RelativeColumn();
+                            columns.RelativeColumn();
+                        });
+
+                        table.Header(header =>
+                        {
+                            header.Cell().Element(CellStyle).Text("Phase");
+                            header.Cell().Element(CellStyle).Text("Task");
+                            header.Cell().Element(CellStyle).Text("Count");
+                        });
+
+                        table.Cell().Element(CellStyle).Text("Setup");
+                        table.Cell().Element(CellStyle).Text("Place tokens");
+                        table.Cell().Element(CellStyle).Text("16");
+
+                        table.Cell().Element(CellStyle).Text("Round Start");
+                        table.Cell().Element(CellStyle).Text(string.Empty); // intentionally empty cell
+                        table.Cell().Element(CellStyle).Text("8");
+                    });
+
+                    column.Item().PaddingTop(20).Image(Placeholders.Image(120, 80));
+                });
+            });
+        }).GeneratePdf(filePath);
+    }
+
+    private static IContainer CellStyle(IContainer container) =>
+        container.Border(0.5f).Padding(5).AlignMiddle();
 
     [Fact]
     public async Task ExtractStructuredContentAsync_WithNullPath_ReturnsFailure()
@@ -140,5 +221,36 @@ public class PdfTableExtractionServiceTests
         Assert.Equal(0, diagram.Width);
         Assert.Equal(0, diagram.Height);
         Assert.Null(diagram.ImageData);
+    }
+
+    [Fact]
+    public async Task ExtractStructuredContentAsync_WithStructuredPdfFixture_ParsesTablesDiagramsAndAtomicRules()
+    {
+        // Arrange
+        var pdfPath = CreateTempPdfPath();
+        CreateStructuredPdf(pdfPath);
+
+        // Act
+        var result = await _service.ExtractStructuredContentAsync(pdfPath);
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.NotEmpty(result.Tables);
+
+        var table = result.Tables.First();
+        Assert.Equal(new[] { "Phase", "Task", "Count" }, table.Headers);
+        Assert.Equal(table.ColumnCount, table.Headers.Count);
+        Assert.True(table.RowCount >= 1);
+        Assert.All(table.Rows, row => Assert.Equal(table.ColumnCount, row.Length));
+        Assert.Contains(table.Rows, row =>
+            row.Length == table.ColumnCount &&
+            row.Any(value => string.IsNullOrWhiteSpace(value)) &&
+            row.Any(value => !string.IsNullOrWhiteSpace(value)));
+
+        Assert.NotEmpty(result.AtomicRules);
+        Assert.Contains(result.AtomicRules, rule => rule.Contains("Setup", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(result.AtomicRules, rule => rule.Contains("Round Start", StringComparison.OrdinalIgnoreCase));
+
+        Assert.NotEmpty(result.Diagrams);
     }
 }


### PR DESCRIPTION
## Summary
- derive PDF table column boundaries from per-character positions and normalize rows to maintain consistent column counts
- reuse the new positional parsing to create tables even when cells are empty and update atomic rule generation
- add a QuestPDF-based structured fixture test that validates table, diagram, and atomic rule extraction

## Testing
- dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj *(fails: Docker unavailable for Qdrant integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e4ebe16c83209893a2e89a67b5a2