### PR TITLE
Remove explicit container names from infra compose stack

### DIFF
--- a/apps/web/.dockerignore
+++ b/apps/web/.dockerignore
@@ -1,0 +1,13 @@
+# Files and directories to ignore in Docker build context
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+.git
+.gitignore
+.next
+out
+coverage
+.vscode
+.env
+.env.*

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -3,7 +3,6 @@ version: "3.9"
 services:
   postgres:
     image: postgres:16-alpine
-    container_name: meepleai-postgres
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-meeple}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-meeplepass}
@@ -23,7 +22,6 @@ services:
 
   qdrant:
     image: qdrant/qdrant:v1.12.4
-    container_name: meepleai-qdrant
     ports:
       - "6333:6333"  # HTTP REST API
       - "6334:6334"  # gRPC API
@@ -39,7 +37,6 @@ services:
 
   redis:
     image: redis:7-alpine
-    container_name: meepleai-redis
     ports:
       - "6379:6379"
     healthcheck:
@@ -52,7 +49,6 @@ services:
 
   n8n:
     image: n8nio/n8n:1.60.0
-    container_name: meepleai-n8n
     env_file:
       - ./env/n8n.env.dev
     ports:
@@ -67,7 +63,6 @@ services:
     build:
       context: ../apps/api
       dockerfile: ./src/Api/Dockerfile
-    container_name: meepleai-api
     env_file:
       - ./env/api.env.dev
     environment:
@@ -97,7 +92,6 @@ services:
     build:
       context: ../apps/web
       dockerfile: ./Dockerfile
-    container_name: meepleai-web
     env_file:
       - ./env/web.env.dev
     ports:


### PR DESCRIPTION
## Summary
- remove the container_name overrides from infra services so docker compose can reuse or recreate containers without conflicts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2e992c4488320b72ae741fbe4c75f