### PR TITLE
Add Playwright E2E coverage for admin, n8n, and versions dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ scripts/, tools/, schemas/ ...
 
 ## Test locali
 
-- Front-end: `cd apps/web && npm test`
+- Front-end unit: `cd apps/web && npm test`
+- Front-end E2E complete suite: `cd apps/web && npm run test:e2e`
+- Front-end E2E mirati per le nuove dashboard (`admin`, `n8n`, `versions`): `cd apps/web && npm run test:e2e -- admin.spec.ts n8n.spec.ts versions.spec.ts`
 - API: `cd apps/api && dotnet test` (richiede .NET 8 SDK installato in locale)
 
 Per altre linee guida consulta `agents.md` e i README specifici nelle rispettive app.

--- a/apps/web/e2e/admin.spec.ts
+++ b/apps/web/e2e/admin.spec.ts
@@ -1,0 +1,185 @@
+import { test, expect, Page } from '@playwright/test';
+
+const apiBase = 'http://localhost:8080';
+
+async function mockAuthenticatedUser(page: Page) {
+  await page.route(`${apiBase}/auth/me`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        user: {
+          id: 'admin-1',
+          email: 'admin@example.com',
+          displayName: 'Admin Example',
+          role: 'Admin'
+        },
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString()
+      })
+    });
+  });
+}
+
+test.describe('Admin dashboard', () => {
+  test('renders analytics, supports filtering and exports CSV', async ({ page }) => {
+    await mockAuthenticatedUser(page);
+
+    const allRequests = [
+      {
+        id: 'req-1',
+        userId: 'user-1',
+        gameId: 'terraforming-mars',
+        endpoint: 'qa',
+        query: 'Strategie per Terraforming Mars?',
+        responseSnippet: 'Concentra la produzione di ossigeno.',
+        latencyMs: 320,
+        tokenCount: 740,
+        promptTokens: 400,
+        completionTokens: 340,
+        confidence: 0.92,
+        status: 'Success',
+        errorMessage: null,
+        ipAddress: '127.0.0.1',
+        userAgent: 'Playwright',
+        createdAt: new Date('2025-01-06T10:15:00Z').toISOString(),
+        model: 'gpt-4.1-mini',
+        finishReason: 'stop'
+      },
+      {
+        id: 'req-2',
+        userId: 'user-2',
+        gameId: 'meeple-arena',
+        endpoint: 'setup',
+        query: 'Meeple setup guidance',
+        responseSnippet: 'Disponi tutti i meeple sul tabellone iniziale.',
+        latencyMs: 480,
+        tokenCount: 560,
+        promptTokens: 260,
+        completionTokens: 300,
+        confidence: 0.76,
+        status: 'Error',
+        errorMessage: 'Timeout backend',
+        ipAddress: '127.0.0.1',
+        userAgent: 'Playwright',
+        createdAt: new Date('2025-01-06T10:20:00Z').toISOString(),
+        model: 'gpt-4.1-mini',
+        finishReason: 'length'
+      }
+    ];
+
+    const qaOnly = [allRequests[0]];
+
+    await page.route(new RegExp(`${apiBase}/admin/requests.*`), async (route) => {
+      const url = new URL(route.request().url());
+      const endpoint = url.searchParams.get('endpoint');
+      const body = endpoint === 'qa' ? { requests: qaOnly } : { requests: allRequests };
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(body)
+      });
+    });
+
+    await page.route(`${apiBase}/admin/stats`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          totalRequests: 2,
+          avgLatencyMs: 400,
+          totalTokens: 1300,
+          successRate: 0.5,
+          endpointCounts: {
+            qa: 1,
+            setup: 1
+          },
+          feedbackCounts: {
+            helpful: 7,
+            'not-helpful': 3
+          },
+          totalFeedback: 10
+        })
+      });
+    });
+
+    await page.addInitScript(() => {
+      (window as any).__downloadBlobs = [] as Blob[];
+      const originalCreateObjectURL = URL.createObjectURL.bind(URL);
+      URL.createObjectURL = (blob: Blob) => {
+        (window as any).__downloadBlobs.push(blob);
+        return originalCreateObjectURL(blob);
+      };
+    });
+
+    await page.goto('/admin');
+
+    await expect(page.getByRole('heading', { name: 'Admin Dashboard' })).toBeVisible();
+    const totalRequestsCard = page.locator('div').filter({ hasText: 'Total Requests' }).first();
+    await expect(totalRequestsCard).toContainText('Total Requests');
+    await expect(totalRequestsCard).toContainText('2');
+    await expect(page.getByText('Success Rate')).toBeVisible();
+    await expect(page.getByText('50.0%')).toBeVisible();
+
+    await expect(page.getByText('Strategie per Terraforming Mars?')).toBeVisible();
+    await expect(page.getByText('Meeple setup guidance')).toBeVisible();
+
+    const filterInput = page.getByPlaceholder('Filter by query, endpoint, user ID, or game ID...');
+    await filterInput.fill('Terraforming');
+
+    await expect(page.locator('text=Meeple setup guidance')).toHaveCount(0);
+    await expect(page.getByText('Strategie per Terraforming Mars?')).toBeVisible();
+
+    await filterInput.fill('');
+
+    const endpointSelect = page.getByRole('combobox');
+    await endpointSelect.selectOption('qa');
+
+    await page.waitForResponse((response) => {
+      return (
+        response.url().startsWith(`${apiBase}/admin/requests`) &&
+        response.url().includes('endpoint=qa') &&
+        response.request().method() === 'GET'
+      );
+    });
+
+    await expect(page.locator('text=Meeple setup guidance')).toHaveCount(0);
+    await expect(page.getByText('Strategie per Terraforming Mars?')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Export CSV' }).click();
+
+    const csvContent = await page.evaluate(async () => {
+      const blobs = (window as any).__downloadBlobs as Blob[];
+      if (!blobs?.length) {
+        return '';
+      }
+      return await blobs[0].text();
+    });
+
+    expect(csvContent).toContain('Timestamp');
+    expect(csvContent).toContain('Strategie per Terraforming Mars?');
+    expect(csvContent).toContain('qa');
+
+    await expect(page.getByText('Feedback Totali')).toBeVisible();
+    await expect(page.getByText('👍 Utile: 7')).toBeVisible();
+    await expect(page.getByText('👎 Non utile: 3')).toBeVisible();
+  });
+
+  test('shows an error state when analytics APIs fail', async ({ page }) => {
+    await mockAuthenticatedUser(page);
+
+    await page.route(new RegExp(`${apiBase}/admin/requests.*`), async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'Internal server error' })
+      });
+    });
+
+    await page.goto('/admin');
+
+    await expect(page.getByRole('heading', { name: 'Error' })).toBeVisible();
+    await expect(page.getByText('Failed to fetch requests')).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Back to Home' })).toBeVisible();
+  });
+});

--- a/apps/web/e2e/n8n.spec.ts
+++ b/apps/web/e2e/n8n.spec.ts
@@ -1,0 +1,206 @@
+import { test, expect } from '@playwright/test';
+
+const apiBase = 'http://localhost:8080';
+
+test.describe('n8n workflow management', () => {
+  test('allows full lifecycle management of n8n configurations', async ({ page }) => {
+    const configs = [
+      {
+        id: 'cfg-1',
+        name: 'Production n8n',
+        baseUrl: 'https://n8n.example.com',
+        webhookUrl: 'https://n8n.example.com/webhook',
+        isActive: true,
+        lastTestedAt: new Date('2025-01-05T09:00:00Z').toISOString(),
+        lastTestResult: 'Last test successful (120ms)',
+        createdAt: new Date('2025-01-01T10:00:00Z').toISOString(),
+        updatedAt: new Date('2025-01-05T09:05:00Z').toISOString()
+      }
+    ];
+
+    await page.addInitScript(() => {
+      (window as any).__alerts = [] as string[];
+      window.alert = (message?: any) => {
+        (window as any).__alerts.push(String(message));
+      };
+      window.confirm = (message?: string) => {
+        (window as any).__confirmMessages = ((window as any).__confirmMessages ?? []) as string[];
+        (window as any).__confirmMessages.push(String(message ?? ''));
+        return true;
+      };
+    });
+
+    await page.route(`${apiBase}/admin/n8n`, async (route) => {
+      const method = route.request().method();
+      if (method === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ configs })
+        });
+        return;
+      }
+
+      if (method === 'POST') {
+        const body = route.request().postDataJSON() as {
+          name: string;
+          baseUrl: string;
+          apiKey: string;
+          webhookUrl: string | null;
+        };
+
+        const newConfig = {
+          id: `cfg-${configs.length + 1}`,
+          name: body.name,
+          baseUrl: body.baseUrl,
+          webhookUrl: body.webhookUrl,
+          isActive: true,
+          lastTestedAt: null,
+          lastTestResult: null,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString()
+        };
+        configs.push(newConfig);
+
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(newConfig)
+        });
+        return;
+      }
+
+      await route.fulfill({ status: 405, body: 'Method not allowed' });
+    });
+
+    await page.route(new RegExp(`${apiBase}/admin/n8n/([^/]+)$`), async (route) => {
+      const url = new URL(route.request().url());
+      const id = url.pathname.split('/').pop()!;
+      const config = configs.find((c) => c.id === id);
+
+      if (!config) {
+        await route.fulfill({ status: 404, body: 'Not found' });
+        return;
+      }
+
+      const method = route.request().method();
+      if (method === 'PUT') {
+        const body = route.request().postDataJSON() as Partial<typeof config> & { apiKey?: string };
+        if (body.name !== undefined) {
+          config.name = body.name as string;
+        }
+        if (body.baseUrl !== undefined) {
+          config.baseUrl = body.baseUrl as string;
+        }
+        if (body.webhookUrl !== undefined) {
+          config.webhookUrl = body.webhookUrl as string | null;
+        }
+        if (body.isActive !== undefined) {
+          config.isActive = body.isActive as boolean;
+        }
+        config.updatedAt = new Date().toISOString();
+
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(config)
+        });
+        return;
+      }
+
+      if (method === 'DELETE') {
+        const index = configs.findIndex((c) => c.id === id);
+        if (index >= 0) {
+          configs.splice(index, 1);
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true })
+        });
+        return;
+      }
+
+      await route.fulfill({ status: 405, body: 'Method not allowed' });
+    });
+
+    await page.route(new RegExp(`${apiBase}/admin/n8n/([^/]+)/test$`), async (route) => {
+      const url = new URL(route.request().url());
+      const id = url.pathname.split('/').slice(-2, -1)[0];
+      const config = configs.find((c) => c.id === id);
+      if (!config) {
+        await route.fulfill({ status: 404, body: 'Not found' });
+        return;
+      }
+
+      config.lastTestedAt = new Date().toISOString();
+      config.lastTestResult = `Test successful for ${config.name}`;
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, message: config.lastTestResult, latencyMs: 85 })
+      });
+    });
+
+    await page.goto('/n8n');
+
+    await expect(page.getByRole('heading', { name: 'n8n Workflow Management' })).toBeVisible();
+    await expect(page.getByText('Production n8n')).toBeVisible();
+    await expect(page.getByText('Active')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Test' }).click();
+
+    await expect(page.getByText('Test successful for Production n8n')).toBeVisible();
+
+    const alerts = await page.evaluate(() => (window as any).__alerts as string[]);
+    expect(alerts.some((message) => message.includes('Test successful for Production n8n'))).toBeTruthy();
+
+    await page.getByRole('button', { name: 'Deactivate' }).click();
+    await expect(page.getByText('Inactive')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Edit' }).click();
+    await expect(page.getByText('Edit Configuration')).toBeVisible();
+
+    await page.getByLabel('Name *').fill('Production n8n Updated');
+    await page.getByLabel('Base URL *').fill('https://n8n.example.com/updated');
+    await page.getByLabel('API Key (leave empty to keep current)').fill('new-api-key');
+    await page.getByLabel('Webhook URL (optional)').fill('https://n8n.example.com/new-webhook');
+    await page.getByRole('button', { name: 'Update Configuration' }).click();
+
+    await expect(page.getByText('Production n8n Updated')).toBeVisible();
+    await expect(page.getByText('https://n8n.example.com/updated')).toBeVisible();
+    await expect(page.getByText('Webhook: https://n8n.example.com/new-webhook')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Delete' }).click();
+    await expect(page.getByText('No n8n configurations found. Click "Add Configuration" to create one.')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Add Configuration' }).click();
+    await expect(page.getByText('New Configuration')).toBeVisible();
+
+    await page.getByPlaceholder('Production n8n').fill('Staging n8n');
+    await page.getByPlaceholder('http://localhost:5678').fill('https://staging.n8n.example.com');
+    await page.getByPlaceholder('n8n API key').fill('staging-key');
+    await page.getByPlaceholder('http://localhost:5678/webhook').fill('https://staging.n8n.example.com/webhook');
+    await page.getByRole('button', { name: 'Create Configuration' }).click();
+
+    await expect(page.getByText('Staging n8n')).toBeVisible();
+    await expect(page.getByText('https://staging.n8n.example.com')).toBeVisible();
+  });
+
+  test('surfaces error when loading n8n configurations fails', async ({ page }) => {
+    await page.route(`${apiBase}/admin/n8n`, async (route) => {
+      await route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'Unauthorized' })
+      });
+    });
+
+    await page.goto('/n8n');
+
+    await expect(page.getByRole('heading', { name: 'Error' })).toBeVisible();
+    await expect(page.getByText('Failed to fetch n8n configurations')).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Back to Home' })).toBeVisible();
+  });
+});

--- a/apps/web/e2e/versions.spec.ts
+++ b/apps/web/e2e/versions.spec.ts
@@ -1,0 +1,256 @@
+import { test, expect, Page } from '@playwright/test';
+
+const apiBase = 'http://localhost:8080';
+
+async function mockAuth(page: Page, shouldAuthenticate = true) {
+  await page.route(`${apiBase}/auth/me`, async (route) => {
+    if (!shouldAuthenticate) {
+      await route.fulfill({ status: 401, contentType: 'application/json', body: JSON.stringify({ error: 'Unauthorized' }) });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        user: {
+          id: 'admin-1',
+          email: 'admin@example.com',
+          role: 'Admin'
+        },
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString()
+      })
+    });
+  });
+}
+
+test.describe('RuleSpec versions history', () => {
+  test('shows history, diff and allows restoring a version', async ({ page }) => {
+    await mockAuth(page, true);
+
+    const historyData = {
+      gameId: 'demo-chess',
+      totalVersions: 3,
+      versions: [
+        {
+          version: 'v3',
+          createdAt: new Date('2025-01-03T09:00:00Z').toISOString(),
+          ruleCount: 58,
+          createdBy: 'admin@example.com'
+        },
+        {
+          version: 'v2',
+          createdAt: new Date('2025-01-02T09:00:00Z').toISOString(),
+          ruleCount: 56,
+          createdBy: 'editor@example.com'
+        },
+        {
+          version: 'v1',
+          createdAt: new Date('2025-01-01T09:00:00Z').toISOString(),
+          ruleCount: 52,
+          createdBy: 'editor@example.com'
+        }
+      ]
+    };
+
+    const specsByVersion: Record<string, any> = {
+      v1: {
+        gameId: 'demo-chess',
+        version: 'v1',
+        createdAt: new Date('2025-01-01T09:00:00Z').toISOString(),
+        rules: [{ id: 'rule-1', text: 'Setup pedine' }]
+      },
+      v2: {
+        gameId: 'demo-chess',
+        version: 'v2',
+        createdAt: new Date('2025-01-02T09:00:00Z').toISOString(),
+        rules: [{ id: 'rule-1', text: 'Setup pedine' }, { id: 'rule-2', text: 'Turno giocatore' }]
+      },
+      v3: {
+        gameId: 'demo-chess',
+        version: 'v3',
+        createdAt: new Date('2025-01-03T09:00:00Z').toISOString(),
+        rules: [
+          { id: 'rule-1', text: 'Setup pedine' },
+          { id: 'rule-2', text: 'Turno giocatore' },
+          { id: 'rule-3', text: 'Scacco matto' }
+        ]
+      }
+    };
+
+    const diffResponses: Record<string, any> = {
+      'v2->v3': {
+        gameId: 'demo-chess',
+        fromVersion: 'v2',
+        toVersion: 'v3',
+        fromCreatedAt: specsByVersion.v2.createdAt,
+        toCreatedAt: specsByVersion.v3.createdAt,
+        summary: { totalChanges: 3, added: 1, modified: 1, deleted: 0, unchanged: 1 },
+        changes: [
+          {
+            type: 'Added',
+            newAtom: 'rule-3',
+            newValue: { id: 'rule-3', text: 'Scacco matto', section: 'Finale', page: '12' }
+          },
+          {
+            type: 'Modified',
+            newAtom: 'rule-2',
+            fieldChanges: [
+              { fieldName: 'text', oldValue: 'Turno giocatore', newValue: 'Sequenza turno aggiornata' }
+            ]
+          },
+          {
+            type: 'Unchanged',
+            oldAtom: 'rule-1',
+            oldValue: { id: 'rule-1', text: 'Setup pedine' }
+          }
+        ]
+      },
+      'v3->v4': {
+        gameId: 'demo-chess',
+        fromVersion: 'v3',
+        toVersion: 'v4',
+        fromCreatedAt: specsByVersion.v3.createdAt,
+        toCreatedAt: new Date('2025-01-04T09:00:00Z').toISOString(),
+        summary: { totalChanges: 1, added: 0, modified: 0, deleted: 0, unchanged: 1 },
+        changes: [
+          {
+            type: 'Unchanged',
+            oldAtom: 'rule-1',
+            oldValue: { id: 'rule-1', text: 'Setup pedine' }
+          }
+        ]
+      }
+    };
+
+    await page.route(`${apiBase}/games/demo-chess/rulespec/history`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(historyData)
+      });
+    });
+
+    await page.route(new RegExp(`${apiBase}/games/demo-chess/rulespec/diff.*`), async (route) => {
+      const url = new URL(route.request().url());
+      const key = `${url.searchParams.get('from')}->${url.searchParams.get('to')}`;
+      const diff = diffResponses[key] ?? diffResponses['v2->v3'];
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(diff)
+      });
+    });
+
+    await page.route(new RegExp(`${apiBase}/games/demo-chess/rulespec/versions/.*`), async (route) => {
+      const version = route.request().url().split('/').pop()!;
+      const spec = specsByVersion[version];
+      if (!spec) {
+        await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'Not found' }) });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(spec)
+      });
+    });
+
+    await page.route(`${apiBase}/games/demo-chess/rulespec`, async (route) => {
+      const restoredSpec = route.request().postDataJSON() as { rules?: unknown[] } & Record<string, any>;
+      const createdAt = new Date('2025-01-04T09:00:00Z').toISOString();
+      const newSpecVersion = {
+        ...restoredSpec,
+        version: 'v4',
+        createdAt
+      };
+
+      historyData.versions = [
+        {
+          version: newSpecVersion.version,
+          createdAt,
+          ruleCount: Array.isArray(restoredSpec.rules) ? restoredSpec.rules.length : 0,
+          createdBy: 'admin@example.com'
+        },
+        ...historyData.versions
+      ];
+      historyData.totalVersions = historyData.versions.length;
+      specsByVersion.v4 = newSpecVersion;
+      diffResponses['v3->v4'] = {
+        ...diffResponses['v3->v4'],
+        toCreatedAt: createdAt
+      };
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(newSpecVersion)
+      });
+    });
+
+    await page.addInitScript(() => {
+      (window as any).__confirmMessages = [] as string[];
+      window.confirm = (message?: string) => {
+        (window as any).__confirmMessages.push(String(message ?? ''));
+        return true;
+      };
+    });
+
+    await page.goto('/versions?gameId=demo-chess');
+
+    await expect(page.getByRole('heading', { name: 'Storico Versioni RuleSpec' })).toBeVisible();
+    await expect(page.getByText('Game: demo-chess')).toBeVisible();
+    await expect(page.getByText('Versioni (3)')).toBeVisible();
+
+    await expect(page.getByText('v3')).toBeVisible();
+    await expect(page.getByText('v2')).toBeVisible();
+    await expect(page.getByText('v1')).toBeVisible();
+
+    await expect(page.getByText('Modifiche (2)')).toBeVisible();
+    await expect(page.getByText('+1')).toBeVisible();
+    await expect(page.getByText('~1')).toBeVisible();
+
+    const diffToggle = page.getByLabel('Mostra solo modifiche');
+    await diffToggle.click();
+    await expect(page.getByText('Modifiche (3)')).toBeVisible();
+
+    const restoreButton = page.getByRole('button', { name: 'Ripristina' }).nth(1);
+    await restoreButton.click();
+
+    const confirmMessages = await page.evaluate(() => (window as any).__confirmMessages as string[]);
+    expect(confirmMessages.some((message) => message.includes('Sei sicuro di voler ripristinare la versione v2'))).toBeTruthy();
+
+    await page.waitForResponse(`${apiBase}/games/demo-chess/rulespec/versions/v2`);
+    await page.waitForResponse(`${apiBase}/games/demo-chess/rulespec`);
+    await page.waitForResponse(`${apiBase}/games/demo-chess/rulespec/history`);
+
+    await expect(page.getByText('Versione v2 ripristinata con successo come versione v4')).toBeVisible();
+    await expect(page.getByText('Versioni (4)')).toBeVisible();
+    await expect(page.getByText('v4')).toBeVisible();
+  });
+
+  test('asks the user to authenticate when no session is present', async ({ page }) => {
+    await mockAuth(page, false);
+
+    await page.goto('/versions?gameId=demo-chess');
+
+    await expect(page.getByText("Devi effettuare l'accesso per visualizzare lo storico.")).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Torna alla home' })).toBeVisible();
+  });
+
+  test('displays an error banner when history retrieval fails', async ({ page }) => {
+    await mockAuth(page, true);
+
+    await page.route(`${apiBase}/games/demo-chess/rulespec/history`, async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'Server error' })
+      });
+    });
+
+    await page.goto('/versions?gameId=demo-chess');
+
+    await expect(page.getByText('Impossibile caricare lo storico versioni.')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright coverage for the admin dashboard including realistic analytics data, filtering, CSV export, and failure handling
- exercise n8n workflow management happy-path and error scenarios with mocked API state transitions
- cover RuleSpec version history authentication, diff viewing, and restore workflows while documenting new E2E commands

## Testing
- npx playwright test admin.spec.ts n8n.spec.ts versions.spec.ts --reporter=list *(fails: Playwright browsers are not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e34fabf2cc8320b95875ab69097423