### PR TITLE
test: expand coverage for PdfTableExtractionService

### DIFF
--- a/apps/api/tests/Api.Tests/PdfTableExtractionServiceTests.cs
+++ b/apps/api/tests/Api.Tests/PdfTableExtractionServiceTests.cs
@@ -1,6 +1,12 @@
 using Api.Services;
+using iText.IO.Image;
+using iText.Kernel.Pdf;
+using iText.Layout;
+using iText.Layout.Element;
 using Microsoft.Extensions.Logging;
 using Moq;
+using System.Linq;
+using System.Reflection;
 using Xunit;
 
 namespace Api.Tests;
@@ -14,6 +20,168 @@ public class PdfTableExtractionServiceTests
     {
         _mockLogger = new Mock<ILogger<PdfTableExtractionService>>();
         _service = new PdfTableExtractionService(_mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task ExtractStructuredContentAsync_WithPdfContainingTableAndImage_PopulatesStructuredCollections()
+    {
+        // Arrange
+        var tempFilePath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.pdf");
+
+        try
+        {
+            using (var writer = new PdfWriter(tempFilePath))
+            using (var pdfDocument = new PdfDocument(writer))
+            using (var document = new Document(pdfDocument))
+            {
+                var table = new Table(2);
+                table.AddHeaderCell("Header 1");
+                table.AddHeaderCell("Header 2");
+                table.AddCell("Row 1 Column 1");
+                table.AddCell("Row 1 Column 2");
+                table.AddCell("Row 2 Column 1");
+                table.AddCell("Row 2 Column 2");
+                document.Add(table);
+
+                var imageBytes = Convert.FromBase64String(
+                    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=");
+                var imageData = ImageDataFactory.Create(imageBytes);
+                var image = new Image(imageData).ScaleToFit(50, 50);
+                document.Add(image);
+            }
+
+            // Act
+            var result = await _service.ExtractStructuredContentAsync(tempFilePath);
+
+            // Assert
+            Assert.True(result.Success);
+            Assert.NotEmpty(result.Tables);
+
+            var firstTable = result.Tables.First();
+            Assert.True(firstTable.ColumnCount >= 2);
+            Assert.True(firstTable.RowCount >= 2);
+
+            Assert.True(result.AtomicRules.Count >= firstTable.RowCount);
+            Assert.Contains(result.AtomicRules, rule => rule.Contains("Row 1 Column 1", StringComparison.OrdinalIgnoreCase));
+
+            Assert.NotEmpty(result.Diagrams);
+            Assert.Contains(result.Diagrams, diagram => diagram.Width > 0 && diagram.Height > 0);
+        }
+        finally
+        {
+            if (File.Exists(tempFilePath))
+            {
+                File.Delete(tempFilePath);
+            }
+        }
+    }
+
+    [Fact]
+    public void DetectTablesInPage_WithIrregularColumnsAndEndOfPage_ReturnsExpectedTables()
+    {
+        // Arrange
+        var pageText = """
+Header 1   Header 2   Header 3
+Value 1    Value 2    Value 3
+Value 4    Value 5
+
+Another Header 1   Another Header 2
+Row A1             Row A2
+""";
+
+        // Act
+        var tables = InvokeDetectTablesInPage(pageText, pageNum: 1);
+
+        // Assert
+        Assert.Equal(2, tables.Count);
+
+        var firstTable = tables[0];
+        Assert.Equal(3, firstTable.ColumnCount);
+        Assert.Equal(2, firstTable.RowCount);
+        Assert.Equal(2, firstTable.Rows[1].Length); // Irregular columns handled
+
+        var secondTable = tables[1];
+        Assert.Equal(2, secondTable.ColumnCount);
+        Assert.Equal(1, secondTable.RowCount);
+    }
+
+    [Fact]
+    public void ConvertTableToAtomicRules_WithSparseRows_CreatesRulesForPopulatedValues()
+    {
+        // Arrange
+        var table = new PdfTable
+        {
+            PageNumber = 2,
+            Headers = new List<string> { "Col1", "Col2", "Col3" },
+            Rows = new List<string[]>
+            {
+                new[] { "Value1", "Value2", string.Empty },
+                new[] { "OnlyFirst", string.Empty, string.Empty },
+                new[] { string.Empty, string.Empty, string.Empty }
+            },
+            ColumnCount = 3
+        };
+
+        // Act
+        var rules = InvokeConvertTableToAtomicRules(table);
+
+        // Assert
+        Assert.Equal(2, rules.Count);
+        Assert.Contains(rules, rule => rule.Contains("Col1: Value1") && rule.Contains("Col2: Value2"));
+        Assert.Contains(rules, rule => rule.Contains("Col1: OnlyFirst") && !rule.Contains("Col2:"));
+    }
+
+    [Fact]
+    public async Task ExtractStructuredContentAsync_WithCorruptedPdf_LogsErrorAndReturnsFailure()
+    {
+        // Arrange
+        var tempFilePath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid()}.pdf");
+        await File.WriteAllTextAsync(tempFilePath, "not a valid pdf");
+
+        try
+        {
+            // Act
+            var result = await _service.ExtractStructuredContentAsync(tempFilePath);
+
+            // Assert
+            Assert.False(result.Success);
+            Assert.NotNull(result.ErrorMessage);
+            Assert.Contains("Extraction failed", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+
+            _mockLogger.Verify(
+                x => x.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((state, _) => state.ToString()!.Contains("Failed to extract structured content")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+        }
+        finally
+        {
+            if (File.Exists(tempFilePath))
+            {
+                File.Delete(tempFilePath);
+            }
+        }
+    }
+
+    private List<PdfTable> InvokeDetectTablesInPage(string pageText, int pageNum)
+    {
+        var method = typeof(PdfTableExtractionService).GetMethod(
+            "DetectTablesInPage",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        return (List<PdfTable>)method!.Invoke(_service, new object[] { pageText, pageNum })!;
+    }
+
+    private List<string> InvokeConvertTableToAtomicRules(PdfTable table)
+    {
+        var method = typeof(PdfTableExtractionService).GetMethod(
+            "ConvertTableToAtomicRules",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        return (List<string>)method!.Invoke(_service, new object[] { table })!;
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add an end-to-end test that generates a sample PDF with a table and image to validate structured extraction
- cover table detection and atomic rule conversion heuristics with irregular layouts and trailing tables
- exercise the error logging path by attempting to parse a corrupted PDF file

## Testing
- dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj *(fails: dotnet CLI not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e355872f9c83209e630694e60c33d9