### PR TITLE
test: expand upload page failure coverage

### DIFF
--- a/apps/web/src/pages/__tests__/upload.test.tsx
+++ b/apps/web/src/pages/__tests__/upload.test.tsx
@@ -13,6 +13,16 @@ describe('UploadPage', () => {
       json: () => Promise.resolve(data)
     } as Response);
 
+  const createErrorResponse = (status: number, body: unknown = { error: 'Error' }, statusText?: string) =>
+    Promise.resolve({
+      ok: false,
+      status,
+      statusText:
+        statusText ??
+        (status === 401 ? 'Unauthorized' : status === 500 ? 'Internal Server Error' : 'Error'),
+      json: () => Promise.resolve(body)
+    } as Response);
+
   beforeEach(() => {
     mockFetch.mockReset();
     global.fetch = mockFetch as unknown as typeof fetch;
@@ -237,6 +247,534 @@ describe('UploadPage', () => {
       );
 
       await waitFor(() => expect(screen.getByText(/Auto generated rule/i)).toBeInTheDocument());
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('displays an error when loading PDFs fails', async () => {
+    const authResponse = {
+      user: {
+        id: 'user-4',
+        email: 'user4@example.com',
+        role: 'Admin',
+        displayName: 'User Four'
+      },
+      expiresAt: new Date().toISOString()
+    };
+
+    mockFetch.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      const method = init?.method ?? 'GET';
+
+      if (url.endsWith('/auth/me')) {
+        return createJsonResponse(authResponse);
+      }
+
+      if (url.endsWith('/games') && method === 'GET') {
+        return createJsonResponse([
+          { id: 'game-1', name: 'Terraforming Mars', createdAt: new Date().toISOString() }
+        ]);
+      }
+
+      if (url.includes('/games/game-1/pdfs')) {
+        return createErrorResponse(500, { error: 'Server error' });
+      }
+
+      throw new Error(`Unexpected fetch call to ${url}`);
+    });
+
+    render(<UploadPage />);
+
+    await waitFor(() => expect(screen.getByLabelText(/Existing games/i)).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /Confirm selection/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Unable to load uploaded PDFs\. Please try again\./i)).toBeInTheDocument()
+    );
+  });
+
+  it('shows parse failure message when polling reports a failed status', async () => {
+    jest.useFakeTimers();
+
+    try {
+      const authResponse = {
+        user: {
+          id: 'user-5',
+          email: 'user5@example.com',
+          role: 'Admin',
+          displayName: 'User Five'
+        },
+        expiresAt: new Date().toISOString()
+      };
+
+      mockFetch.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        const method = init?.method ?? 'GET';
+
+        if (url.endsWith('/auth/me')) {
+          return createJsonResponse(authResponse);
+        }
+
+        if (url.endsWith('/games') && method === 'GET') {
+          return createJsonResponse([
+            { id: 'game-1', name: 'Terraforming Mars', createdAt: new Date().toISOString() }
+          ]);
+        }
+
+        if (url.includes('/games/game-1/pdfs')) {
+          return createJsonResponse({ pdfs: [] });
+        }
+
+        if (url.endsWith('/ingest/pdf')) {
+          return createJsonResponse({ documentId: 'pdf-123', fileName: 'rules.pdf' });
+        }
+
+        if (url.endsWith('/pdfs/pdf-123/text')) {
+          return createJsonResponse({
+            id: 'pdf-123',
+            fileName: 'rules.pdf',
+            processingStatus: 'failed',
+            processingError: 'OCR error'
+          });
+        }
+
+        throw new Error(`Unexpected fetch call to ${url}`);
+      });
+
+      render(<UploadPage />);
+
+      await waitFor(() => expect(screen.getByLabelText(/Existing games/i)).toBeInTheDocument());
+
+      fireEvent.click(screen.getByRole('button', { name: /Confirm selection/i }));
+
+      const fileInput = screen.getByLabelText(/PDF File/i) as HTMLInputElement;
+      const file = new File(['pdf'], 'rules.pdf', { type: 'application/pdf' });
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      const uploadButton = screen.getByRole('button', { name: /Upload & Continue/i });
+      await waitFor(() => expect(uploadButton).not.toBeDisabled());
+      fireEvent.click(uploadButton);
+
+      await waitFor(() => expect(screen.getByText(/Processing status/i)).toBeInTheDocument());
+
+      await waitFor(() =>
+        expect(screen.getByText(/❌ Parse failed: OCR error/i)).toBeInTheDocument()
+      );
+      expect(screen.getByText(/Processing error: OCR error/i)).toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('shows polling error when status request fails', async () => {
+    jest.useFakeTimers();
+
+    try {
+      const authResponse = {
+        user: {
+          id: 'user-6',
+          email: 'user6@example.com',
+          role: 'Admin',
+          displayName: 'User Six'
+        },
+        expiresAt: new Date().toISOString()
+      };
+
+      const ruleSpecResponse = {
+        gameId: 'game-1',
+        version: 'v1',
+        createdAt: new Date().toISOString(),
+        rules: [{ id: 'r1', text: 'Rule text' }]
+      };
+
+      let statusCallCount = 0;
+
+      mockFetch.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        const method = init?.method ?? 'GET';
+
+        if (url.endsWith('/auth/me')) {
+          return createJsonResponse(authResponse);
+        }
+
+        if (url.endsWith('/games') && method === 'GET') {
+          return createJsonResponse([
+            { id: 'game-1', name: 'Terraforming Mars', createdAt: new Date().toISOString() }
+          ]);
+        }
+
+        if (url.includes('/games/game-1/pdfs')) {
+          return createJsonResponse({ pdfs: [] });
+        }
+
+        if (url.endsWith('/ingest/pdf')) {
+          return createJsonResponse({ documentId: 'pdf-123', fileName: 'rules.pdf' });
+        }
+
+        if (url.endsWith('/pdfs/pdf-123/text')) {
+          statusCallCount += 1;
+          if (statusCallCount === 1) {
+            return Promise.reject(new Error('Network down'));
+          }
+          if (statusCallCount === 2) {
+            return createJsonResponse({
+              id: 'pdf-123',
+              fileName: 'rules.pdf',
+              processingStatus: 'processing',
+              processingError: null
+            });
+          }
+          return createJsonResponse({
+            id: 'pdf-123',
+            fileName: 'rules.pdf',
+            processingStatus: 'completed',
+            processingError: null
+          });
+        }
+
+        if (url.endsWith('/games/game-1/rulespec')) {
+          return createJsonResponse(ruleSpecResponse);
+        }
+
+        throw new Error(`Unexpected fetch call to ${url}`);
+      });
+
+      render(<UploadPage />);
+
+      await waitFor(() => expect(screen.getByLabelText(/Existing games/i)).toBeInTheDocument());
+
+      fireEvent.click(screen.getByRole('button', { name: /Confirm selection/i }));
+
+      const fileInput = screen.getByLabelText(/PDF File/i) as HTMLInputElement;
+      const file = new File(['pdf'], 'rules.pdf', { type: 'application/pdf' });
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      const uploadButton = screen.getByRole('button', { name: /Upload & Continue/i });
+      await waitFor(() => expect(uploadButton).not.toBeDisabled());
+      fireEvent.click(uploadButton);
+
+      await waitFor(() =>
+        expect(screen.getByText(/Status refresh failed: Network down/i)).toBeInTheDocument()
+      );
+
+      await act(async () => {
+        jest.advanceTimersByTime(4000);
+      });
+      await act(async () => {
+        jest.advanceTimersByTime(2000);
+      });
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole('heading', { name: /Step 3: Review & Edit Rules/i })
+        ).toBeInTheDocument()
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('shows an error message when the upload request fails', async () => {
+    const authResponse = {
+      user: {
+        id: 'user-7',
+        email: 'user7@example.com',
+        role: 'Admin',
+        displayName: 'User Seven'
+      },
+      expiresAt: new Date().toISOString()
+    };
+
+    mockFetch.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      const method = init?.method ?? 'GET';
+
+      if (url.endsWith('/auth/me')) {
+        return createJsonResponse(authResponse);
+      }
+
+      if (url.endsWith('/games') && method === 'GET') {
+        return createJsonResponse([
+          { id: 'game-1', name: 'Terraforming Mars', createdAt: new Date().toISOString() }
+        ]);
+      }
+
+      if (url.includes('/games/game-1/pdfs')) {
+        return createJsonResponse({ pdfs: [] });
+      }
+
+      if (url.endsWith('/ingest/pdf')) {
+        return createErrorResponse(500, { error: 'Upload exploded' });
+      }
+
+      throw new Error(`Unexpected fetch call to ${url}`);
+    });
+
+    render(<UploadPage />);
+
+    await waitFor(() => expect(screen.getByLabelText(/Existing games/i)).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /Confirm selection/i }));
+
+    const fileInput = screen.getByLabelText(/PDF File/i) as HTMLInputElement;
+    const file = new File(['pdf'], 'rules.pdf', { type: 'application/pdf' });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    const uploadButton = screen.getByRole('button', { name: /Upload & Continue/i });
+    await waitFor(() => expect(uploadButton).not.toBeDisabled());
+    fireEvent.click(uploadButton);
+
+    await waitFor(() =>
+      expect(screen.getByText(/❌ Upload failed: Upload exploded/i)).toBeInTheDocument()
+    );
+  });
+
+  it('keeps the wizard on the parse step when the rulespec response is null', async () => {
+    jest.useFakeTimers();
+
+    try {
+      const authResponse = {
+        user: {
+          id: 'user-8',
+          email: 'user8@example.com',
+          role: 'Admin',
+          displayName: 'User Eight'
+        },
+        expiresAt: new Date().toISOString()
+      };
+
+      mockFetch.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        const method = init?.method ?? 'GET';
+
+        if (url.endsWith('/auth/me')) {
+          return createJsonResponse(authResponse);
+        }
+
+        if (url.endsWith('/games') && method === 'GET') {
+          return createJsonResponse([
+            { id: 'game-1', name: 'Terraforming Mars', createdAt: new Date().toISOString() }
+          ]);
+        }
+
+        if (url.includes('/games/game-1/pdfs')) {
+          return createJsonResponse({ pdfs: [] });
+        }
+
+        if (url.endsWith('/ingest/pdf')) {
+          return createJsonResponse({ documentId: 'pdf-123', fileName: 'rules.pdf' });
+        }
+
+        if (url.endsWith('/pdfs/pdf-123/text')) {
+          return createJsonResponse({
+            id: 'pdf-123',
+            fileName: 'rules.pdf',
+            processingStatus: 'completed',
+            processingError: null
+          });
+        }
+
+        if (url.endsWith('/games/game-1/rulespec')) {
+          return createErrorResponse(401, {});
+        }
+
+        throw new Error(`Unexpected fetch call to ${url}`);
+      });
+
+      render(<UploadPage />);
+
+      await waitFor(() => expect(screen.getByLabelText(/Existing games/i)).toBeInTheDocument());
+
+      fireEvent.click(screen.getByRole('button', { name: /Confirm selection/i }));
+
+      const fileInput = screen.getByLabelText(/PDF File/i) as HTMLInputElement;
+      const file = new File(['pdf'], 'rules.pdf', { type: 'application/pdf' });
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      const uploadButton = screen.getByRole('button', { name: /Upload & Continue/i });
+      await waitFor(() => expect(uploadButton).not.toBeDisabled());
+      fireEvent.click(uploadButton);
+
+      await waitFor(() =>
+        expect(screen.getByText(/❌ Parse failed: Unable to load RuleSpec\./i)).toBeInTheDocument()
+      );
+      expect(screen.getByRole('heading', { name: /Step 2: Parse PDF/i })).toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('shows an error message when handleParse throws', async () => {
+    jest.useFakeTimers();
+
+    try {
+      const authResponse = {
+        user: {
+          id: 'user-9',
+          email: 'user9@example.com',
+          role: 'Admin',
+          displayName: 'User Nine'
+        },
+        expiresAt: new Date().toISOString()
+      };
+
+      mockFetch.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        const method = init?.method ?? 'GET';
+
+        if (url.endsWith('/auth/me')) {
+          return createJsonResponse(authResponse);
+        }
+
+        if (url.endsWith('/games') && method === 'GET') {
+          return createJsonResponse([
+            { id: 'game-1', name: 'Terraforming Mars', createdAt: new Date().toISOString() }
+          ]);
+        }
+
+        if (url.includes('/games/game-1/pdfs')) {
+          return createJsonResponse({ pdfs: [] });
+        }
+
+        if (url.endsWith('/ingest/pdf')) {
+          return createJsonResponse({ documentId: 'pdf-123', fileName: 'rules.pdf' });
+        }
+
+        if (url.endsWith('/pdfs/pdf-123/text')) {
+          return createJsonResponse({
+            id: 'pdf-123',
+            fileName: 'rules.pdf',
+            processingStatus: 'completed',
+            processingError: null
+          });
+        }
+
+        if (url.endsWith('/games/game-1/rulespec')) {
+          return createErrorResponse(500, { error: 'Server exploded' });
+        }
+
+        throw new Error(`Unexpected fetch call to ${url}`);
+      });
+
+      render(<UploadPage />);
+
+      await waitFor(() => expect(screen.getByLabelText(/Existing games/i)).toBeInTheDocument());
+
+      fireEvent.click(screen.getByRole('button', { name: /Confirm selection/i }));
+
+      const fileInput = screen.getByLabelText(/PDF File/i) as HTMLInputElement;
+      const file = new File(['pdf'], 'rules.pdf', { type: 'application/pdf' });
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      const uploadButton = screen.getByRole('button', { name: /Upload & Continue/i });
+      await waitFor(() => expect(uploadButton).not.toBeDisabled());
+      fireEvent.click(uploadButton);
+
+      await waitFor(() =>
+        expect(
+          screen.getByText(/❌ Parse failed: API \/games\/game-1\/rulespec 500/i)
+        ).toBeInTheDocument()
+      );
+      expect(screen.getByRole('heading', { name: /Step 2: Parse PDF/i })).toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('shows a failure message when publishing the rulespec fails', async () => {
+    jest.useFakeTimers();
+
+    try {
+      const authResponse = {
+        user: {
+          id: 'user-10',
+          email: 'user10@example.com',
+          role: 'Admin',
+          displayName: 'User Ten'
+        },
+        expiresAt: new Date().toISOString()
+      };
+
+      const ruleSpecResponse = {
+        gameId: 'game-1',
+        version: 'v1',
+        createdAt: new Date().toISOString(),
+        rules: [{ id: 'r1', text: 'Auto generated rule', section: 'Intro', page: '1', line: '1' }]
+      };
+
+      mockFetch.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        const method = init?.method ?? 'GET';
+
+        if (url.endsWith('/auth/me')) {
+          return createJsonResponse(authResponse);
+        }
+
+        if (url.endsWith('/games') && method === 'GET') {
+          return createJsonResponse([
+            { id: 'game-1', name: 'Terraforming Mars', createdAt: new Date().toISOString() }
+          ]);
+        }
+
+        if (url.includes('/games/game-1/pdfs') && method === 'GET') {
+          return createJsonResponse({ pdfs: [] });
+        }
+
+        if (url.endsWith('/ingest/pdf')) {
+          return createJsonResponse({ documentId: 'pdf-123', fileName: 'rules.pdf' });
+        }
+
+        if (url.endsWith('/pdfs/pdf-123/text')) {
+          return createJsonResponse({
+            id: 'pdf-123',
+            fileName: 'rules.pdf',
+            processingStatus: 'completed',
+            processingError: null
+          });
+        }
+
+        if (url.endsWith('/games/game-1/rulespec') && method === 'GET') {
+          return createJsonResponse(ruleSpecResponse);
+        }
+
+        if (url.endsWith('/games/game-1/rulespec') && method === 'PUT') {
+          return createErrorResponse(500, { error: 'Publish failed' });
+        }
+
+        throw new Error(`Unexpected fetch call to ${url}`);
+      });
+
+      render(<UploadPage />);
+
+      await waitFor(() => expect(screen.getByLabelText(/Existing games/i)).toBeInTheDocument());
+
+      fireEvent.click(screen.getByRole('button', { name: /Confirm selection/i }));
+
+      const fileInput = screen.getByLabelText(/PDF File/i) as HTMLInputElement;
+      const file = new File(['pdf'], 'rules.pdf', { type: 'application/pdf' });
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      const uploadButton = screen.getByRole('button', { name: /Upload & Continue/i });
+      await waitFor(() => expect(uploadButton).not.toBeDisabled());
+      fireEvent.click(uploadButton);
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole('heading', { name: /Step 3: Review & Edit Rules/i })
+        ).toBeInTheDocument()
+      );
+
+      const publishButton = screen.getByRole('button', { name: /Publish RuleSpec/i });
+      fireEvent.click(publishButton);
+
+      await waitFor(() =>
+        expect(screen.getByText(/❌ Publish failed: Publish failed/i)).toBeInTheDocument()
+      );
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /Publish RuleSpec/i })).toBeInTheDocument()
+      );
     } finally {
       jest.useRealTimers();
     }


### PR DESCRIPTION
## Summary
- add a helper for building error responses in the upload page test suite
- cover PDF list loading errors, polling failures, and upload error messaging
- assert parse and publish failure paths leave the wizard in the correct step with surfaced errors

## Testing
- npm test -- upload

------
https://chatgpt.com/codex/tasks/task_e_68e35588ea0c83209a60351965b18c97