### PR TITLE
test: add coverage for health api handler

### DIFF
--- a/apps/web/src/pages/api/__tests__/health.test.ts
+++ b/apps/web/src/pages/api/__tests__/health.test.ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import handler from "../health";
+
+describe("health API handler", () => {
+  it("responds with status 200 and ok true", () => {
+    const status = jest.fn().mockReturnThis();
+    const json = jest.fn();
+    const res = {
+      status,
+      json,
+    } as unknown as NextApiResponse;
+
+    handler({} as NextApiRequest, res);
+
+    expect(status).toHaveBeenCalledTimes(1);
+    expect(status).toHaveBeenCalledWith(200);
+    expect(json).toHaveBeenCalledTimes(1);
+    expect(json).toHaveBeenCalledWith({ ok: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add a Jest test for the health API handler to assert the 200/ok response

## Testing
- npm test -- --coverage *(fails: global coverage thresholds unmet, existing issue)*

------
https://chatgpt.com/codex/tasks/task_e_68e3558b2df08320b05bf316e34ac057