### PR TITLE
fix: set session cookies for cross-site usage

### DIFF
--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -1124,8 +1124,8 @@ static void WriteSessionCookie(HttpContext context, string token, DateTime expir
     var options = new CookieOptions
     {
         HttpOnly = true,
-        Secure = context.Request.IsHttps,
-        SameSite = SameSiteMode.Strict,
+        Secure = true,
+        SameSite = SameSiteMode.None,
         Path = "/",
         Expires = new DateTimeOffset(expiresAt)
     };
@@ -1138,8 +1138,8 @@ static void RemoveSessionCookie(HttpContext context)
     var options = new CookieOptions
     {
         HttpOnly = true,
-        Secure = context.Request.IsHttps,
-        SameSite = SameSiteMode.Strict,
+        Secure = true,
+        SameSite = SameSiteMode.None,
         Path = "/",
         Expires = DateTimeOffset.UnixEpoch
     };


### PR DESCRIPTION
## Summary
- set the API session cookie to always be secure with SameSite=None for compatibility with cross-site requests

## Testing
- npm run test:e2e -- --project=chromium --grep "allows a user to log in" *(fails: host system missing Playwright browser dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e35efee770832092b4a165edfe87ac