### PR TITLE
Fix forwarded headers and session cookie settings

### DIFF
--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -1,12 +1,15 @@
 using Api.Infrastructure;
 using System;
 using System.Linq;
+using System.Net;
 using System.Security.Claims;
 using Api.Infrastructure.Entities;
 using Api.Models;
 using Api.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.Options;
 using Serilog;
 using Serilog.Events;
 using StackExchange.Redis;
@@ -26,6 +29,42 @@ Log.Logger = new LoggerConfiguration()
     .CreateLogger();
 
 builder.Host.UseSerilog();
+
+var forwardedHeadersSection = builder.Configuration.GetSection("ForwardedHeaders");
+builder.Services.Configure<ForwardedHeadersOptions>(options =>
+{
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+
+    var knownProxies = forwardedHeadersSection.GetSection("KnownProxies").Get<string[]>() ?? Array.Empty<string>();
+    var knownNetworks = forwardedHeadersSection.GetSection("KnownNetworks").Get<string[]>() ?? Array.Empty<string>();
+
+    options.KnownNetworks.Clear();
+    options.KnownProxies.Clear();
+
+    foreach (var proxy in knownProxies)
+    {
+        if (IPAddress.TryParse(proxy, out var ipAddress))
+        {
+            options.KnownProxies.Add(ipAddress);
+        }
+    }
+
+    foreach (var network in knownNetworks)
+    {
+        if (IPNetwork.TryParse(network, out var ipNetwork))
+        {
+            options.KnownNetworks.Add(ipNetwork);
+        }
+    }
+
+    var forwardLimit = forwardedHeadersSection.GetValue<int?>("ForwardLimit");
+    if (forwardLimit.HasValue)
+    {
+        options.ForwardLimit = forwardLimit.Value;
+    }
+});
+
+builder.Services.Configure<SessionCookieConfiguration>(builder.Configuration.GetSection("Authentication:SessionCookie"));
 
 var connectionString = builder.Configuration.GetConnectionString("Postgres")
     ?? builder.Configuration["ConnectionStrings__Postgres"]
@@ -113,6 +152,8 @@ using (var scope = app.Services.CreateScope())
         await qdrant.EnsureCollectionExistsAsync();
     }
 }
+
+app.UseForwardedHeaders();
 
 app.UseCors("web");
 
@@ -1121,29 +1162,87 @@ app.Run();
 
 static void WriteSessionCookie(HttpContext context, string token, DateTime expiresAt)
 {
-    var options = new CookieOptions
-    {
-        HttpOnly = true,
-        Secure = context.Request.IsHttps,
-        SameSite = SameSiteMode.Strict,
-        Path = "/",
-        Expires = new DateTimeOffset(expiresAt)
-    };
+    var options = CreateSessionCookieOptions(context);
+    options.Expires = new DateTimeOffset(expiresAt);
 
     context.Response.Cookies.Append(AuthService.SessionCookieName, token, options);
 }
 
 static void RemoveSessionCookie(HttpContext context)
 {
+    var options = CreateSessionCookieOptions(context);
+    options.Expires = DateTimeOffset.UnixEpoch;
+
+    context.Response.Cookies.Delete(AuthService.SessionCookieName, options);
+}
+
+static CookieOptions CreateSessionCookieOptions(HttpContext context)
+{
+    var configuration = context.RequestServices.GetService<IOptions<SessionCookieConfiguration>>()?.Value
+                       ?? new SessionCookieConfiguration();
+
     var options = new CookieOptions
     {
         HttpOnly = true,
-        Secure = context.Request.IsHttps,
-        SameSite = SameSiteMode.Strict,
-        Path = "/",
-        Expires = DateTimeOffset.UnixEpoch
+        SameSite = configuration.SameSite,
+        Secure = configuration.SecurePolicy switch
+        {
+            CookieSecurePolicy.Always => true,
+            CookieSecurePolicy.None => false,
+            _ => IsSecureRequest(context)
+        },
+        Path = string.IsNullOrWhiteSpace(configuration.Path) ? "/" : configuration.Path
     };
 
-    context.Response.Cookies.Delete(AuthService.SessionCookieName, options);
+    if (!string.IsNullOrWhiteSpace(configuration.Domain))
+    {
+        options.Domain = configuration.Domain;
+    }
+
+    return options;
+}
+
+static bool IsSecureRequest(HttpContext context)
+{
+    if (context.Request.IsHttps)
+    {
+        return true;
+    }
+
+    if (context.Request.Headers.TryGetValue("X-Forwarded-Proto", out var forwardedProto) &&
+        forwardedProto.Any(value => string.Equals(value, "https", StringComparison.OrdinalIgnoreCase)))
+    {
+        return true;
+    }
+
+    if (context.Request.Headers.TryGetValue("Forwarded", out var forwardedValues))
+    {
+        foreach (var value in forwardedValues)
+        {
+            var segments = value.Split(new[] { ';', ',' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var segment in segments)
+            {
+                var trimmed = segment.Trim();
+                if (trimmed.StartsWith("proto=", StringComparison.OrdinalIgnoreCase))
+                {
+                    var proto = trimmed.Substring("proto=".Length);
+                    if (string.Equals(proto, "https", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
+public sealed class SessionCookieConfiguration
+{
+    public CookieSecurePolicy SecurePolicy { get; set; } = CookieSecurePolicy.SameAsRequest;
+    public SameSiteMode SameSite { get; set; } = SameSiteMode.Strict;
+    public string Path { get; set; } = "/";
+    public string? Domain { get; set; }
 }
 public partial class Program { }


### PR DESCRIPTION
## Summary
- configure forwarded headers support so reverse proxy HTTPS is honored when determining request security
- apply the forwarded headers middleware before other components that rely on HttpContext.Request.IsHttps
- centralize session cookie option handling with secure detection and configuration support for proxied deployments

## Testing
- ⚠️ `dotnet build apps/api/src/Api/Api.csproj` *(fails in container: dotnet CLI is unavailable)*


------
https://chatgpt.com/codex/tasks/task_e_68e35f012ee883208323464899ec16cf