### PR TITLE
Restrict game creation endpoint to editor and admin roles

### DIFF
--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -663,9 +663,19 @@ app.MapGet("/games", async (HttpContext context, GameService gameService, Cancel
 
 app.MapPost("/games", async (CreateGameRequest? request, HttpContext context, GameService gameService, ILogger<Program> logger, CancellationToken ct) =>
 {
-    if (!context.Items.TryGetValue(nameof(ActiveSession), out var value) || value is not ActiveSession)
+    if (!context.Items.TryGetValue(nameof(ActiveSession), out var value) || value is not ActiveSession session)
     {
         return Results.Unauthorized();
+    }
+
+    if (!string.Equals(session.User.role, UserRole.Admin.ToString(), StringComparison.OrdinalIgnoreCase) &&
+        !string.Equals(session.User.role, UserRole.Editor.ToString(), StringComparison.OrdinalIgnoreCase))
+    {
+        logger.LogWarning(
+            "User {UserId} with role {Role} attempted to create a game without permission",
+            session.User.id,
+            session.User.role);
+        return Results.StatusCode(StatusCodes.Status403Forbidden);
     }
 
     if (request is null)


### PR DESCRIPTION
## Summary
- add an authorization guard to the /games POST endpoint so only editors and admins can create games
- log unauthorized creation attempts and respond with HTTP 403 for non-privileged users
- extend integration coverage to confirm admins and editors can create games while standard users receive 403

## Testing
- dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e360040d80832088066f3d88302178