### PR TITLE
Fix filters handling missing identifiers in logs and admin pages

### DIFF
--- a/apps/web/src/pages/__tests__/admin.test.tsx
+++ b/apps/web/src/pages/__tests__/admin.test.tsx
@@ -241,6 +241,60 @@ describe('AdminDashboard', () => {
     expect(revokeObjectURLMock).toHaveBeenCalledWith('blob:mock-url');
   });
 
+  it('handles requests without user or game identifiers when filtering', async () => {
+    const requestsPayload = {
+      requests: [
+        {
+          id: '3',
+          userId: null,
+          gameId: null,
+          endpoint: 'qa',
+          query: null,
+          responseSnippet: null,
+          latencyMs: 120,
+          tokenCount: 24,
+          promptTokens: 12,
+          completionTokens: 12,
+          confidence: null,
+          status: 'Success',
+          errorMessage: null,
+          ipAddress: '127.0.0.3',
+          userAgent: 'jest',
+          createdAt: '2024-01-03T12:00:00.000Z',
+          model: null,
+          finishReason: null
+        }
+      ]
+    };
+
+    const statsPayload = {
+      totalRequests: 1,
+      avgLatencyMs: 120,
+      totalTokens: 24,
+      successRate: 1,
+      endpointCounts: { qa: 1 },
+      feedbackCounts: {},
+      totalFeedback: 0
+    };
+
+    fetchMock
+      .mockResolvedValueOnce(createJsonResponse(requestsPayload))
+      .mockResolvedValueOnce(createJsonResponse(statsPayload));
+
+    const user = userEvent.setup();
+
+    render(<AdminDashboard />);
+
+    expect(await screen.findByText('Admin Dashboard')).toBeInTheDocument();
+
+    const filterInput = screen.getByPlaceholderText('Filter by query, endpoint, user ID, or game ID...');
+
+    await user.type(filterInput, 'qa');
+
+    expect(screen.getAllByText('qa').length).toBeGreaterThan(0);
+    expect(screen.getByText('Success')).toBeInTheDocument();
+  });
+
   it('renders error state when the API responds with an error', async () => {
     fetchMock.mockResolvedValueOnce(createJsonResponse({}, false));
 

--- a/apps/web/src/pages/__tests__/logs.test.tsx
+++ b/apps/web/src/pages/__tests__/logs.test.tsx
@@ -67,4 +67,26 @@ describe('LogsPage', () => {
     expect(screen.getByText(/No logs found/i)).toBeInTheDocument();
     expect(screen.getByText(/basic observability dashboard/i)).toBeInTheDocument();
   });
+
+  it('handles logs without request or user identifiers when filtering', async () => {
+    const logsWithoutIds = [
+      {
+        timestamp: new Date('2024-01-01T11:00:00Z').toISOString(),
+        level: 'INFO',
+        message: 'System maintenance in progress'
+      }
+    ];
+
+    mockGet.mockResolvedValueOnce(logsWithoutIds);
+
+    const user = userEvent.setup();
+
+    render(<LogsPage />);
+
+    const filterInput = await screen.findByPlaceholderText(/Filter logs/i);
+
+    await user.type(filterInput, 'maintenance');
+
+    expect(screen.getByText(/System maintenance in progress/i)).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/pages/admin.tsx
+++ b/apps/web/src/pages/admin.tsx
@@ -131,10 +131,10 @@ export default function AdminDashboard() {
 
   const filteredRequests = requests.filter(
     (req) =>
-      req.query?.toLowerCase().includes(filter.toLowerCase()) ||
+      req.query?.toLowerCase()?.includes(filter.toLowerCase()) ||
       req.endpoint.toLowerCase().includes(filter.toLowerCase()) ||
-      req.userId?.toLowerCase().includes(filter.toLowerCase()) ||
-      req.gameId?.toLowerCase().includes(filter.toLowerCase())
+      req.userId?.toLowerCase()?.includes(filter.toLowerCase()) ||
+      req.gameId?.toLowerCase()?.includes(filter.toLowerCase())
   );
 
   const helpfulCount = stats?.feedbackCounts?.["helpful"] ?? 0;

--- a/apps/web/src/pages/logs.tsx
+++ b/apps/web/src/pages/logs.tsx
@@ -50,8 +50,8 @@ export default function LogsPage() {
   const filteredLogs = logs.filter(
     (log) =>
       log.message.toLowerCase().includes(filter.toLowerCase()) ||
-      log.requestId?.toLowerCase().includes(filter.toLowerCase()) ||
-      log.userId?.toLowerCase().includes(filter.toLowerCase())
+      log.requestId?.toLowerCase()?.includes(filter.toLowerCase()) ||
+      log.userId?.toLowerCase()?.includes(filter.toLowerCase())
   );
 
   const getLevelColor = (level: string) => {


### PR DESCRIPTION
## Summary
- guard log and admin filter predicates when optional identifiers are absent
- add unit coverage for log entries and admin requests lacking requestId/userId

## Testing
- npm test -- --runTestsByPath src/pages/__tests__/logs.test.tsx src/pages/__tests__/admin.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e360086804832081667f33e3a00639