### PR TITLE
Fix CORS allowed origins configuration handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Questo repository ospita gli stack principali di MeepleAI:
 
 Ogni servizio espone un healthcheck nel `docker-compose.yml`, per cui `docker compose ps` mostra lo stato "healthy" quando l'avvio è completo.
 
+### Configurazione CORS per ambienti non locali
+
+- Le API leggono l'elenco di origini consentite dalla chiave di configurazione `AllowedOrigins` (array di stringhe). In `appsettings.json` locale è già presente un esempio con `http://localhost:3000`.
+- In produzione/staging imposta il valore tramite variabili d'ambiente (`AllowedOrigins__0=https://app.example.com`, `AllowedOrigins__1=https://app-alt.example.com`, ...). È supportata anche la chiave legacy `Cors:AllowedOrigins` per retrocompatibilità.
+- Se non viene definita alcuna origine, l'API ricade sul valore di default `http://localhost:3000`, quindi assicurati di popolare la configurazione nei deploy non locali per evitare errori CORS.
+
 ## Database
 
 ### Avvio di Postgres via Docker Compose

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -76,6 +76,11 @@ builder.Services.AddScoped<N8nConfigService>();
 
 var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? Array.Empty<string>();
 
+if (allowedOrigins.Length == 0)
+{
+    allowedOrigins = builder.Configuration.GetSection("AllowedOrigins").Get<string[]>() ?? Array.Empty<string>();
+}
+
 builder.Services.AddCors(options =>
 {
     options.AddPolicy("web", policy =>

--- a/apps/api/tests/Api.Tests/CorsConfigurationTests.cs
+++ b/apps/api/tests/Api.Tests/CorsConfigurationTests.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Cors.Infrastructure;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests;
+
+public class CorsConfigurationTests : IClassFixture<WebApplicationFactoryFixture>
+{
+    private readonly WebApplicationFactoryFixture _factory;
+
+    public CorsConfigurationTests(WebApplicationFactoryFixture factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task CustomOriginsAreLoadedFromTopLevelAllowedOriginsSection()
+    {
+        const string origin = "https://prod.example.com";
+
+        using var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Staging");
+            builder.ConfigureAppConfiguration((_, configBuilder) =>
+            {
+                configBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["AllowedOrigins:0"] = origin
+                });
+            });
+        });
+
+        using var scope = factory.Services.CreateScope();
+        var corsPolicyProvider = scope.ServiceProvider.GetRequiredService<ICorsPolicyProvider>();
+
+        var policy = await corsPolicyProvider.GetPolicyAsync(new DefaultHttpContext(), "web");
+
+        Assert.NotNull(policy);
+        Assert.Contains(origin, policy!.Origins);
+    }
+}


### PR DESCRIPTION
## Summary
- read allowed origins from the existing top-level `AllowedOrigins` configuration section while retaining the legacy nested key as a fallback
- add a regression test to ensure custom origins load when the API runs outside the local environment
- document how to configure CORS origins for staging and production deployments

## Testing
- dotnet test *(fails: `dotnet` command not found in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e360095b808320ba5aa09c917fa817