### PR TITLE
fix(api): handle RedisResult array from rate limit script

### DIFF
--- a/apps/api/tests/Api.Tests/RateLimitServiceTests.cs
+++ b/apps/api/tests/Api.Tests/RateLimitServiceTests.cs
@@ -86,7 +86,12 @@ public class RateLimitServiceTests
 
     private static Mock<IConnectionMultiplexer> CreateMockRedis(bool allowRequest, int tokensRemaining, int retryAfter)
     {
-        var resultArray = new RedisValue[] { allowRequest ? 1 : 0, tokensRemaining, retryAfter };
+        var resultArray = new RedisResult[]
+        {
+            RedisResult.Create(allowRequest ? 1 : 0),
+            RedisResult.Create(tokensRemaining),
+            RedisResult.Create(retryAfter)
+        };
 
         var mockDatabase = new Mock<IDatabase>();
         mockDatabase


### PR DESCRIPTION
## Summary
- update the rate limit service to treat Redis script responses as RedisResult[] and convert them to integers safely
- log and return parsed values from the Lua script using a dedicated conversion helper
- adjust rate limit unit and integration tests to simulate RedisResult arrays so invalid casts are caught

## Testing
- dotnet test *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e360054d4c8320bc61c2f7db7d27c4