### PR TITLE
fix: correct session cookie helper usage

### DIFF
--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -1235,14 +1235,16 @@ app.MapPost("/admin/n8n/{configId}/test", async (string configId, HttpContext co
 
 app.Run();
 
-static CookieOptions CreateSessionCookieOptions(DateTimeOffset expiresAt)
+static CookieOptions CreateSessionCookieOptions(HttpContext context, DateTime expiresAt)
 {
     var options = BuildSessionCookieOptions(context);
-    options.Expires = new DateTimeOffset(expiresAt);
+    options.Expires = expiresAt;
+    return options;
+}
 
 static void WriteSessionCookie(HttpContext context, string token, DateTime expiresAt)
 {
-    var options = CreateSessionCookieOptions(new DateTimeOffset(expiresAt));
+    var options = CreateSessionCookieOptions(context, expiresAt);
     context.Response.Cookies.Append(AuthService.SessionCookieName, token, options);
 }
 


### PR DESCRIPTION
## Summary
- ensure CreateSessionCookieOptions builds cookie settings from the current HttpContext and applies the expiry
- update WriteSessionCookie to pass the HttpContext and keep helper methods scoped correctly

## Testing
- dotnet build *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e366e24b4483209b8c439e9aae43c3