### PR TITLE
Fix duplicate ForwardedHeaders configuration variable

### DIFF
--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -137,7 +137,6 @@ builder.Services.AddCors(options =>
     });
 });
 
-var forwardedHeadersSection = builder.Configuration.GetSection("ForwardedHeaders");
 var forwardedHeadersEnabled = forwardedHeadersSection.GetValue<bool?>("Enabled") ?? true;
 
 if (forwardedHeadersEnabled)


### PR DESCRIPTION
## Summary
- remove the duplicated ForwardedHeaders configuration variable declaration and reuse the existing section reference

## Testing
- dotnet build apps/api *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e3642c830c8320b9b6b90120f88885