### PR TITLE
fix: clean admin api import and n8n typing

### DIFF
--- a/apps/web/e2e/n8n.spec.ts
+++ b/apps/web/e2e/n8n.spec.ts
@@ -2,9 +2,21 @@ import { test, expect } from '@playwright/test';
 
 const apiBase = 'http://localhost:8080';
 
+type N8nConfig = {
+  id: string;
+  name: string;
+  baseUrl: string;
+  webhookUrl: string | null;
+  isActive: boolean;
+  lastTestedAt: string | null;
+  lastTestResult: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
 test.describe('n8n workflow management', () => {
   test('allows full lifecycle management of n8n configurations', async ({ page }) => {
-    const configs = [
+    const configs: N8nConfig[] = [
       {
         id: 'cfg-1',
         name: 'Production n8n',
@@ -49,7 +61,7 @@ test.describe('n8n workflow management', () => {
           webhookUrl: string | null;
         };
 
-        const newConfig = {
+        const newConfig: N8nConfig = {
           id: `cfg-${configs.length + 1}`,
           name: body.name,
           baseUrl: body.baseUrl,

--- a/apps/web/src/pages/admin.tsx
+++ b/apps/web/src/pages/admin.tsx
@@ -1,7 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
-import { API_BASE } from "../lib/api";
-
 import { getApiBase } from "../lib/api";
 
 type AiRequest = {


### PR DESCRIPTION
## Summary
- remove the unused API_BASE import from the admin dashboard page
- add an explicit N8nConfig type in the Playwright spec so nullable fields match the app contract

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e369ed8cb48320a1324ba5a0ccce6e