### PR TITLE
Fix Redis result parsing in rate limit service

### DIFF
--- a/apps/api/src/Api/Services/RateLimitService.cs
+++ b/apps/api/src/Api/Services/RateLimitService.cs
@@ -138,8 +138,9 @@ public class RateLimitService
 
     private static int ConvertRedisResultToInt(RedisResult result)
     {
-        if (result.TryParse(out long longValue))
+        if (result.Resp3Type == ResultType.Integer || result.Resp2Type == ResultType.Integer)
         {
+            var longValue = (long)result;
             return (int)longValue;
         }
 
@@ -150,7 +151,7 @@ public class RateLimitService
             return parsed;
         }
 
-        throw new InvalidOperationException($"Unexpected Redis script result type: {result.Type}");
+        throw new InvalidOperationException($"Unexpected Redis script result type: Resp3Type={result.Resp3Type}, Resp2Type={result.Resp2Type}");
     }
 }
 


### PR DESCRIPTION
## Summary
- replace RedisResult.TryParse usage with Resp2Type/Resp3Type aware integer handling
- update the rate limit service exception message to reference Resp2Type/Resp3Type

## Testing
- dotnet build -warnaserror *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e36a03bbdc8320853553c3d7063b27