### PR TITLE
fix: import hosting for cors tests

### DIFF
--- a/apps/api/tests/Api.Tests/CorsConfigurationTests.cs
+++ b/apps/api/tests/Api.Tests/CorsConfigurationTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Cors.Infrastructure;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
## Summary
- add the Microsoft.AspNetCore.Hosting namespace to the CorsConfigurationTests fixture so UseEnvironment is available

## Testing
- dotnet build apps/api/tests/Api.Tests/Api.Tests.csproj *(fails: dotnet CLI is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3735b4e6c832094d6b0a0bccc7105