### PR TITLE
test: replace SkipException usage in Qdrant integration tests

### DIFF
--- a/apps/api/tests/Api.Tests/QdrantIntegrationTestBase.cs
+++ b/apps/api/tests/Api.Tests/QdrantIntegrationTestBase.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Testcontainers.Qdrant;
 using Xunit;
-using Xunit.Sdk;
 
 namespace Api.Tests;
 
@@ -59,7 +58,7 @@ public abstract class QdrantIntegrationTestBase : IAsyncLifetime
     {
         if (_skipReason is not null)
         {
-            throw new SkipException(_skipReason);
+            Skip.If(true, _skipReason!);
         }
 
         if (_qdrantContainer != null)
@@ -75,7 +74,7 @@ public abstract class QdrantIntegrationTestBase : IAsyncLifetime
             {
                 _skipReason =
                     $"Qdrant integration tests skipped: failed to start local Testcontainers instance and no QDRANT_URL was provided. {ex.Message}";
-                throw new SkipException(_skipReason);
+                Skip.If(true, _skipReason);
             }
         }
 
@@ -83,7 +82,7 @@ public abstract class QdrantIntegrationTestBase : IAsyncLifetime
         {
             _skipReason =
                 "Qdrant integration tests skipped: no QDRANT_URL configured and Docker/Testcontainers is unavailable.";
-            throw new SkipException(_skipReason);
+            Skip.If(true, _skipReason);
         }
 
         // Create QdrantService with Qdrant connection (works for both CI and local)


### PR DESCRIPTION
## Summary
- replace the deprecated SkipException usage in the Qdrant integration test base with xUnit's Skip helper to preserve skip reasons
- remove the now-unused xUnit.Sdk import

## Testing
- `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj` *(fails: `dotnet` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3735e523083208b8c620b817e4b51