### PR TITLE
chore: add missing reflection import to tests

### DIFF
--- a/apps/api/tests/Api.Tests/PdfTableExtractionServiceTests.cs
+++ b/apps/api/tests/Api.Tests/PdfTableExtractionServiceTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using Api.Services;
 using iText.IO.Image;
 using iText.Kernel.Pdf;


### PR DESCRIPTION
## Summary
- add the System.Reflection namespace import to PdfTableExtractionServiceTests so BindingFlags references resolve

## Testing
- `dotnet build` *(fails: `dotnet` command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3736417b483209b6e279f7d00d92f