### PR TITLE
Fix duplicate N8nConfig type definition in e2e spec

### DIFF
--- a/apps/web/e2e/n8n.spec.ts
+++ b/apps/web/e2e/n8n.spec.ts
@@ -1,17 +1,5 @@
 import { test, expect } from '@playwright/test';
 
-type N8nConfig = {
-  id: string;
-  name: string;
-  baseUrl: string;
-  webhookUrl: string | null;
-  isActive: boolean;
-  lastTestedAt: string | null;
-  lastTestResult: string | null;
-  createdAt: string;
-  updatedAt: string;
-};
-
 const apiBase = 'http://localhost:8080';
 
 type N8nConfig = {


### PR DESCRIPTION
## Summary
- remove the redundant N8nConfig type declaration in the n8n Playwright spec to satisfy the TypeScript compiler

## Testing
- pnpm --filter @meepleai/web typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e37529e50c832087f5c10c6b043412