### PR TITLE
Fix dynamic skip handling in Qdrant integration tests

### DIFF
--- a/apps/api/tests/Api.Tests/QdrantIntegrationTestBase.cs
+++ b/apps/api/tests/Api.Tests/QdrantIntegrationTestBase.cs
@@ -58,7 +58,7 @@ public abstract class QdrantIntegrationTestBase : IAsyncLifetime
     {
         if (_skipReason is not null)
         {
-            throw new Xunit.Sdk.SkipException(_skipReason!);
+            throw Xunit.Sdk.SkipException.ForSkip(_skipReason!);
         }
 
         if (_qdrantContainer != null)
@@ -74,7 +74,7 @@ public abstract class QdrantIntegrationTestBase : IAsyncLifetime
             {
                 _skipReason =
                     $"Qdrant integration tests skipped: failed to start local Testcontainers instance and no QDRANT_URL was provided. {ex.Message}";
-                throw new Xunit.Sdk.SkipException(_skipReason);
+                throw Xunit.Sdk.SkipException.ForSkip(_skipReason);
             }
         }
 
@@ -82,7 +82,7 @@ public abstract class QdrantIntegrationTestBase : IAsyncLifetime
         {
             _skipReason =
                 "Qdrant integration tests skipped: no QDRANT_URL configured and Docker/Testcontainers is unavailable.";
-            throw new Xunit.Sdk.SkipException(_skipReason);
+            throw Xunit.Sdk.SkipException.ForSkip(_skipReason);
         }
 
         // Create QdrantService with Qdrant connection (works for both CI and local)


### PR DESCRIPTION
## Summary
- replace direct SkipException instantiation with the SkipException.ForSkip factory in QdrantIntegrationTestBase so dynamic skips work with xUnit 2.6.6

## Testing
- dotnet build apps/api/MeepleAI.Api.sln *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e38ee503788320937f078814a2cdf8