### PR TITLE
Update API integration tests to emulate HTTPS clients

### DIFF
--- a/apps/api/tests/Api.Tests/AdminEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/AdminEndpointsIntegrationTests.cs
@@ -33,7 +33,7 @@ public class AdminEndpointsIntegrationTests : IClassFixture<WebApplicationFactor
     [Fact]
     public async Task GetAdminRequests_AdminReceivesFilteredLogsWithMetadata()
     {
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateHttpsClient();
         var adminEmail = $"admin-requests-{Guid.NewGuid():N}@example.com";
         var adminCookies = await RegisterAndAuthenticateAsync(client, adminEmail, "Admin");
         var adminUserId = await GetUserIdByEmailAsync(adminEmail);
@@ -92,7 +92,7 @@ public class AdminEndpointsIntegrationTests : IClassFixture<WebApplicationFactor
     [Fact]
     public async Task GetAdminStats_AdminReceivesAggregatedValues()
     {
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateHttpsClient();
         var adminEmail = $"admin-stats-{Guid.NewGuid():N}@example.com";
         var adminCookies = await RegisterAndAuthenticateAsync(client, adminEmail, "Admin");
         var adminUserId = await GetUserIdByEmailAsync(adminEmail);
@@ -146,7 +146,7 @@ public class AdminEndpointsIntegrationTests : IClassFixture<WebApplicationFactor
     [MemberData(nameof(NonAdminRoles))]
     public async Task GetAdminRequests_ReturnsForbiddenForNonAdminRoles(string role)
     {
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateHttpsClient();
         var email = $"{role.ToLowerInvariant()}-requests-{Guid.NewGuid():N}@example.com";
         var cookies = await RegisterAndAuthenticateAsync(client, email, role);
 
@@ -161,7 +161,7 @@ public class AdminEndpointsIntegrationTests : IClassFixture<WebApplicationFactor
     [Fact]
     public async Task GetAdminRequests_ReturnsUnauthorizedForAnonymousUser()
     {
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateHttpsClient();
         var response = await client.GetAsync("/admin/requests");
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
@@ -170,7 +170,7 @@ public class AdminEndpointsIntegrationTests : IClassFixture<WebApplicationFactor
     [MemberData(nameof(NonAdminRoles))]
     public async Task GetAdminStats_ReturnsForbiddenForNonAdminRoles(string role)
     {
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateHttpsClient();
         var email = $"{role.ToLowerInvariant()}-stats-{Guid.NewGuid():N}@example.com";
         var cookies = await RegisterAndAuthenticateAsync(client, email, role);
 
@@ -185,7 +185,7 @@ public class AdminEndpointsIntegrationTests : IClassFixture<WebApplicationFactor
     [Fact]
     public async Task GetAdminStats_ReturnsUnauthorizedForAnonymousUser()
     {
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateHttpsClient();
         var response = await client.GetAsync("/admin/stats");
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
@@ -194,7 +194,7 @@ public class AdminEndpointsIntegrationTests : IClassFixture<WebApplicationFactor
     [MemberData(nameof(NonAdminRoles))]
     public async Task PostAdminN8n_ReturnsForbiddenForNonAdminRoles(string role)
     {
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateHttpsClient();
         var email = $"{role.ToLowerInvariant()}-n8n-{Guid.NewGuid():N}@example.com";
         var cookies = await RegisterAndAuthenticateAsync(client, email, role);
 
@@ -214,7 +214,7 @@ public class AdminEndpointsIntegrationTests : IClassFixture<WebApplicationFactor
     {
         await ClearN8nConfigsAsync();
 
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateHttpsClient();
         var adminEmail = $"admin-n8n-create-{Guid.NewGuid():N}@example.com";
         var cookies = await RegisterAndAuthenticateAsync(client, adminEmail, "Admin");
         var adminUserId = await GetUserIdByEmailAsync(adminEmail);
@@ -262,7 +262,7 @@ public class AdminEndpointsIntegrationTests : IClassFixture<WebApplicationFactor
     {
         await ClearN8nConfigsAsync();
 
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateHttpsClient();
         var adminEmail = $"admin-n8n-get-{Guid.NewGuid():N}@example.com";
         var cookies = await RegisterAndAuthenticateAsync(client, adminEmail, "Admin");
         var adminUserId = await GetUserIdByEmailAsync(adminEmail);
@@ -287,7 +287,7 @@ public class AdminEndpointsIntegrationTests : IClassFixture<WebApplicationFactor
     {
         await ClearN8nConfigsAsync();
 
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateHttpsClient();
         var adminEmail = $"admin-n8n-update-{Guid.NewGuid():N}@example.com";
         var cookies = await RegisterAndAuthenticateAsync(client, adminEmail, "Admin");
         var adminUserId = await GetUserIdByEmailAsync(adminEmail);
@@ -339,7 +339,7 @@ public class AdminEndpointsIntegrationTests : IClassFixture<WebApplicationFactor
     [Fact]
     public async Task DeleteAdminN8n_ReturnsNotFoundForMissingConfig()
     {
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateHttpsClient();
         var adminEmail = $"admin-n8n-delete-{Guid.NewGuid():N}@example.com";
         var cookies = await RegisterAndAuthenticateAsync(client, adminEmail, "Admin");
 
@@ -358,7 +358,7 @@ public class AdminEndpointsIntegrationTests : IClassFixture<WebApplicationFactor
     {
         await ClearN8nConfigsAsync();
 
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateHttpsClient();
         var adminEmail = $"admin-n8n-test-{Guid.NewGuid():N}@example.com";
         var cookies = await RegisterAndAuthenticateAsync(client, adminEmail, "Admin");
         var adminUserId = await GetUserIdByEmailAsync(adminEmail);

--- a/apps/api/tests/Api.Tests/ApiEndpointIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/ApiEndpointIntegrationTests.cs
@@ -32,7 +32,7 @@ public class ApiEndpointIntegrationTests : IClassFixture<WebApplicationFactoryFi
     [Fact]
     public async Task Register_ReturnsAuthResponseWithoutTenantInformation()
     {
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateHttpsClient();
 
         var payload = new RegisterPayload(
             "register-user@example.com",
@@ -66,7 +66,7 @@ public class ApiEndpointIntegrationTests : IClassFixture<WebApplicationFactoryFi
         var email = "login-user@example.com";
         await RegisterUserAsync(email);
 
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateHttpsClient();
         var payload = new LoginPayload
         {
             email = email,
@@ -94,7 +94,7 @@ public class ApiEndpointIntegrationTests : IClassFixture<WebApplicationFactoryFi
     [Fact]
     public async Task SeedEndpoint_AllowsAdminWithoutTenantPayload()
     {
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateHttpsClient();
         var cookies = await RegisterAndAuthenticateAsync(client, "seed-admin@example.com", role: "Admin");
 
         var request = new HttpRequestMessage(HttpMethod.Post, "/admin/seed")
@@ -122,7 +122,7 @@ public class ApiEndpointIntegrationTests : IClassFixture<WebApplicationFactoryFi
     [Fact]
     public async Task GenerateRuleSpecFromPdf_ReturnsStructuredSpec()
     {
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateHttpsClient();
         var email = "pdf-parser@example.com";
         var cookies = await RegisterAndAuthenticateAsync(client, email, role: "Admin");
 
@@ -186,7 +186,7 @@ public class ApiEndpointIntegrationTests : IClassFixture<WebApplicationFactoryFi
 
     private async Task RegisterUserAsync(string email, string role = "Admin")
     {
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateHttpsClient();
         await RegisterAndAuthenticateAsync(client, email, role);
     }
 
@@ -223,7 +223,7 @@ public class ApiEndpointIntegrationTests : IClassFixture<WebApplicationFactoryFi
     [InlineData("Editor")]
     public async Task Register_ReturnsConflictWhenNonBootstrapRequestsElevatedRole(string requestedRole)
     {
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateHttpsClient();
 
         var initialPayload = new RegisterPayload(
             $"initial-{Guid.NewGuid():N}@example.com",

--- a/apps/api/tests/Api.Tests/GameEndpointsTests.cs
+++ b/apps/api/tests/Api.Tests/GameEndpointsTests.cs
@@ -19,7 +19,7 @@ public class GameEndpointsTests : IClassFixture<WebApplicationFactoryFixture>
     public GameEndpointsTests(WebApplicationFactoryFixture factory)
     {
         _factory = factory;
-        _client = factory.CreateClient();
+        _client = factory.CreateHttpsClient();
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/LogsEndpointTests.cs
+++ b/apps/api/tests/Api.Tests/LogsEndpointTests.cs
@@ -60,7 +60,7 @@ public class LogsEndpointTests : IClassFixture<WebApplicationFactoryFixture>
             await db.SaveChangesAsync();
         }
 
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateHttpsClient();
         var cookies = await RegisterAndAuthenticateAsync(client, $"admin-logs-{Guid.NewGuid():N}@example.com", "Admin");
 
         var request = new HttpRequestMessage(HttpMethod.Get, "/logs");
@@ -90,7 +90,7 @@ public class LogsEndpointTests : IClassFixture<WebApplicationFactoryFixture>
     [Fact]
     public async Task GetLogs_ReturnsUnauthorizedWhenSessionMissing()
     {
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateHttpsClient();
         var response = await client.GetAsync("/logs");
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -106,7 +106,7 @@ public class LogsEndpointTests : IClassFixture<WebApplicationFactoryFixture>
     [MemberData(nameof(NonAdminRoles))]
     public async Task GetLogs_ReturnsForbiddenForNonAdminRoles(string role)
     {
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateHttpsClient();
         var cookies = await RegisterAndAuthenticateAsync(client, $"{role.ToLowerInvariant()}-logs-{Guid.NewGuid():N}@example.com", role);
 
         var request = new HttpRequestMessage(HttpMethod.Get, "/logs");

--- a/apps/api/tests/Api.Tests/PdfIngestEndpointsTests.cs
+++ b/apps/api/tests/Api.Tests/PdfIngestEndpointsTests.cs
@@ -31,7 +31,7 @@ public class PdfIngestEndpointsTests : IClassFixture<WebApplicationFactoryFixtur
     [Fact]
     public async Task PostRulespecIngest_ReturnsGeneratedRuleSpec()
     {
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateHttpsClient();
         var email = "pdf-ingest@example.com";
         var cookies = await RegisterAndAuthenticateAsync(client, email);
 

--- a/apps/api/tests/Api.Tests/RateLimitingIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/RateLimitingIntegrationTests.cs
@@ -83,7 +83,7 @@ public class RateLimitingIntegrationTests : IClassFixture<WebApplicationFactoryF
             services.AddSingleton<RateLimitService>(sp => sp.GetRequiredService<TestRateLimitService>());
         });
 
-        var client = factory.CreateClient();
+        var client = factory.CreateHttpsClient();
         return new TestClientContext(factory, client, rateLimitService);
     }
 
@@ -98,14 +98,14 @@ public class RateLimitingIntegrationTests : IClassFixture<WebApplicationFactoryF
 
     private sealed class TestClientContext : IDisposable
     {
-        public TestClientContext(WebApplicationFactory<Program> factory, HttpClient client, TestRateLimitService rateLimitService)
+        public TestClientContext(WebApplicationFactoryFixture factory, HttpClient client, TestRateLimitService rateLimitService)
         {
             Factory = factory;
             Client = client;
             RateLimitService = rateLimitService;
         }
 
-        public WebApplicationFactory<Program> Factory { get; }
+        public WebApplicationFactoryFixture Factory { get; }
         public HttpClient Client { get; }
         public TestRateLimitService RateLimitService { get; }
 

--- a/apps/api/tests/Api.Tests/RuleSpecHistoryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/RuleSpecHistoryIntegrationTests.cs
@@ -65,7 +65,7 @@ public class RuleSpecHistoryIntegrationTests : IClassFixture<WebApplicationFacto
         await CreateGameAsync(gameId, "History Unauthorized Game");
         await SeedRuleSpecVersionsAsync(gameId, adminUserId);
 
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateHttpsClient();
         var response = await client.GetAsync($"/games/{gameId}/rulespec/history");
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -142,7 +142,7 @@ public class RuleSpecHistoryIntegrationTests : IClassFixture<WebApplicationFacto
         await CreateGameAsync(gameId, "Versions Unauthorized Game");
         await SeedRuleSpecVersionsAsync(gameId, adminUserId);
 
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateHttpsClient();
         var response = await client.GetAsync($"/games/{gameId}/rulespec/versions/v1");
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -253,7 +253,7 @@ public class RuleSpecHistoryIntegrationTests : IClassFixture<WebApplicationFacto
         await CreateGameAsync(gameId, "Diff Unauthorized Game");
         await SeedRuleSpecVersionsAsync(gameId, adminUserId);
 
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateHttpsClient();
         var response = await client.GetAsync($"/games/{gameId}/rulespec/diff?from=v1&to=v2");
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -350,7 +350,7 @@ public class RuleSpecHistoryIntegrationTests : IClassFixture<WebApplicationFacto
 
     private async Task<string> RegisterUserAsync(string role)
     {
-        using var client = _factory.CreateClient();
+        using var client = _factory.CreateHttpsClient();
         var email = $"{role.ToLowerInvariant()}-{Guid.NewGuid():N}@example.com";
         var payload = new RegisterPayload(email, "Password123!", $"{role} User", null);
         var response = await client.PostAsJsonAsync("/auth/register", payload);
@@ -365,7 +365,7 @@ public class RuleSpecHistoryIntegrationTests : IClassFixture<WebApplicationFacto
 
     private async Task<AuthenticatedClient> CreateAuthenticatedClientAsync(string role)
     {
-        var client = _factory.CreateClient();
+        var client = _factory.CreateHttpsClient();
         var email = $"{role.ToLowerInvariant()}-{Guid.NewGuid():N}@example.com";
         var payload = new RegisterPayload(email, "Password123!", $"{role} User", null);
         var response = await client.PostAsJsonAsync("/auth/register", payload);

--- a/apps/api/tests/Api.Tests/WebApplicationFactoryFixture.cs
+++ b/apps/api/tests/Api.Tests/WebApplicationFactoryFixture.cs
@@ -127,11 +127,19 @@ public class WebApplicationFactoryFixture : WebApplicationFactory<Program>
         }
     }
 
-    public WebApplicationFactory<Program> WithTestServices(Action<IServiceCollection> configureServices)
+    public WebApplicationFactoryFixture WithTestServices(Action<IServiceCollection> configureServices)
     {
-        return WithWebHostBuilder(builder =>
+        return (WebApplicationFactoryFixture)WithWebHostBuilder(builder =>
         {
             builder.ConfigureTestServices(configureServices);
         });
     }
+
+    public HttpClient CreateHttpsClient(WebApplicationFactoryClientOptions? options = null)
+    {
+        options ??= new WebApplicationFactoryClientOptions();
+        options.HandleCookies = false;
+        options.BaseAddress ??= new Uri("https://localhost");
+        return CreateClient(options);
     }
+}


### PR DESCRIPTION
## Summary
- add a helper on the API test web application factory to create HTTPS clients without automatic cookie handling
- update integration tests that perform register/login flows to use HTTPS clients so secure cookie assertions reflect runtime behavior

## Testing
- dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~ApiEndpointIntegrationTests" *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e392d2c7348320869a179b92caf1ee