### PR TITLE
Fix table extraction heuristics for ReportLab PDFs

### DIFF
--- a/apps/api/src/Api/Services/PdfTableExtractionService.cs
+++ b/apps/api/src/Api/Services/PdfTableExtractionService.cs
@@ -115,6 +115,12 @@ public class PdfTableExtractionService
 
             if (string.IsNullOrWhiteSpace(trimmedText))
             {
+                if (currentBoundaries != null && currentBoundaries.Count > 0 && currentRows.Count > 0)
+                {
+                    currentRows.Add(Enumerable.Repeat(string.Empty, currentBoundaries.Count).ToArray());
+                    continue;
+                }
+
                 FinalizeCurrentTable();
                 continue;
             }
@@ -136,6 +142,25 @@ public class PdfTableExtractionService
             }
             else
             {
+                if (currentBoundaries.Count > 0 && line.Characters.Count > 0)
+                {
+                    var rowStart = line.Characters.Min(c => c.X);
+                    var rowEnd = line.Characters.Max(c => c.EndX);
+                    var firstBoundary = currentBoundaries[0];
+                    var lastBoundary = currentBoundaries[^1];
+                    var driftTolerance = Math.Max(8f, line.GetAverageCharacterWidth() * 3f);
+
+                    var extendsLeft = rowStart < firstBoundary.Start - driftTolerance;
+                    var extendsRight = rowEnd > lastBoundary.End + driftTolerance;
+
+                    if (extendsLeft || extendsRight)
+                    {
+                        FinalizeCurrentTable();
+                        i--;
+                        continue;
+                    }
+                }
+
                 var split = SplitIntoColumns(line, currentBoundaries);
                 var boundariesForRow = split.Boundaries;
                 var columnCount = boundariesForRow.Count;
@@ -410,17 +435,42 @@ public class PdfTableExtractionService
             }
         }
 
+        var averageWidth = line.GetAverageCharacterWidth();
+        var baseline = Math.Max(6f, averageWidth > 0 ? averageWidth * 2f : 6f);
+
         if (gaps.Count == 0)
         {
-            return Math.Max(6f, line.GetAverageCharacterWidth() * 2.5f);
+            return baseline;
         }
 
         gaps.Sort();
-        var median = gaps[gaps.Count / 2];
-        var averageWidth = line.GetAverageCharacterWidth();
-        var baseline = averageWidth > 0 ? averageWidth * 2f : 6f;
 
-        return Math.Max(median * 1.8f, Math.Max(6f, baseline));
+        var smallGapThreshold = baseline * 1.75f;
+        var smallGaps = gaps.Where(gap => gap <= smallGapThreshold).ToList();
+
+        float threshold;
+
+        if (smallGaps.Count >= 2)
+        {
+            var typicalGap = smallGaps.Average();
+            threshold = typicalGap * 1.5f;
+        }
+        else if (smallGaps.Count == 1 && gaps.Count > 1)
+        {
+            var median = gaps[gaps.Count / 2];
+            threshold = median * 0.9f;
+        }
+        else
+        {
+            var candidate = gaps.Min() * 0.9f;
+            threshold = candidate;
+        }
+
+        var upperBound = baseline * 4f;
+        threshold = Math.Min(threshold, upperBound);
+        threshold = Math.Max(threshold, baseline);
+
+        return threshold;
     }
 
     private List<PositionedTextLine> ExtractPageLines(PdfPage page)


### PR DESCRIPTION
## Summary
- treat whitespace-only table rows as empty cells instead of terminating detection
- detect and finalize tables when subsequent content drifts outside the established column boundaries
- cap the column gap threshold using baseline character widths so wide ReportLab gaps still split into distinct columns

## Testing
- `dotnet test --filter FullyQualifiedName~ExtractStructuredContentAsync_WithStructuredPdf_ReturnsTablesAndDiagrams`
- `dotnet test --filter FullyQualifiedName~ExtractStructuredContentAsync_WithStructuredPdfFixture`


------
https://chatgpt.com/codex/tasks/task_e_68e392c639c08320ae1e9ebc3313e951