### PR TITLE
Adjust rate limiting test factory usage

### DIFF
--- a/apps/api/tests/Api.Tests/RateLimitingIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/RateLimitingIntegrationTests.cs
@@ -147,14 +147,14 @@ public class RateLimitingIntegrationTests : IClassFixture<WebApplicationFactoryF
 
     private sealed class TestClientContext : IDisposable, IAsyncDisposable
     {
-        public TestClientContext(WebApplicationFactoryFixture factory, HttpClient client, TestRateLimitService rateLimitService)
+        public TestClientContext(WebApplicationFactory<Program> factory, HttpClient client, TestRateLimitService rateLimitService)
         {
             Factory = factory;
             Client = client;
             RateLimitService = rateLimitService;
         }
 
-        public WebApplicationFactoryFixture Factory { get; }
+        public WebApplicationFactory<Program> Factory { get; }
         public HttpClient Client { get; }
         public TestRateLimitService RateLimitService { get; }
 

--- a/apps/api/tests/Api.Tests/WebApplicationFactoryFixture.cs
+++ b/apps/api/tests/Api.Tests/WebApplicationFactoryFixture.cs
@@ -127,9 +127,9 @@ public class WebApplicationFactoryFixture : WebApplicationFactory<Program>
         }
     }
 
-    public WebApplicationFactoryFixture WithTestServices(Action<IServiceCollection> configureServices)
+    public WebApplicationFactory<Program> WithTestServices(Action<IServiceCollection> configureServices)
     {
-        return (WebApplicationFactoryFixture)WithWebHostBuilder(builder =>
+        return WithWebHostBuilder(builder =>
         {
             builder.ConfigureTestServices(configureServices);
         });


### PR DESCRIPTION
## Summary
- return the delegated factory from WithTestServices without casting back to the fixture type
- update rate limiting integration test context to store the generalized WebApplicationFactory instance

## Testing
- dotnet test --filter RateLimitingIntegrationTests *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3a044dcdc832081518c101a47179b