### PR TITLE
fix: enforce secure session cookie defaults

### DIFF
--- a/apps/api/src/Api/Models/SessionCookieConfiguration.cs
+++ b/apps/api/src/Api/Models/SessionCookieConfiguration.cs
@@ -12,8 +12,16 @@ public record SessionCookieConfiguration
 
     public bool HttpOnly { get; init; } = true;
 
+    /// <summary>
+    /// Explicitly sets the secure flag on the session cookie. When omitted the application forces secure cookies
+    /// even for HTTP requests (e.g. behind reverse proxies or during in-memory tests) unless disabled explicitly.
+    /// </summary>
     public bool? Secure { get; init; }
 
+    /// <summary>
+    /// Sets the SameSite mode. If the secure flag is forced by the application this value will be coerced to
+    /// <see cref="SameSiteMode.None"/> to support cross-site scenarios.
+    /// </summary>
     public SameSiteMode? SameSite { get; init; }
 
     public bool UseForwardedProto { get; init; } = true;

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -1294,7 +1294,20 @@ static CookieOptions BuildSessionCookieOptions(HttpContext context)
     }
 
     var secure = configuration.Secure ?? isHttps;
+    var secureForced = false;
+
+    if (!secure && !configuration.Secure.HasValue)
+    {
+        secure = true;
+        secureForced = true;
+    }
+
     var sameSite = configuration.SameSite ?? (secure ? SameSiteMode.None : SameSiteMode.Lax);
+
+    if (secureForced && sameSite != SameSiteMode.None)
+    {
+        sameSite = SameSiteMode.None;
+    }
     var path = string.IsNullOrWhiteSpace(configuration.Path) ? "/" : configuration.Path;
 
     var options = new CookieOptions


### PR DESCRIPTION
## Summary
- force session cookies to secure mode when configuration does not specify a value and respect X-Forwarded-Proto detection
- coerce SameSite to None when secure is forced to support cross-site auth in integration tests
- document the default secure behaviour and SameSite coercion in SessionCookieConfiguration

## Testing
- `dotnet test apps/api/tests` *(fails: dotnet CLI not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3a05cbafc8320924e207c6f1a2c63