### PR TITLE
Fix missing namespace for CorsOptions

### DIFF
--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -6,6 +6,7 @@ using System.Security.Claims;
 using Api.Infrastructure.Entities;
 using Api.Models;
 using Api.Services;
+using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.HttpOverrides;

--- a/apps/api/tests/Api.Tests/GameEndpointsTests.cs
+++ b/apps/api/tests/Api.Tests/GameEndpointsTests.cs
@@ -127,15 +127,9 @@ public class GameEndpointsTests : IClassFixture<WebApplicationFactoryFixture>
         return setCookie.Select(cookie => cookie.Split(';')[0]).ToList();
     }
 
-    private async Task PromoteUserAsync(string email, string role)
+    private async Task PromoteUserAsync(string email, UserRole role)
     {
-        if (string.IsNullOrWhiteSpace(role) ||
-            string.Equals(role, nameof(UserRole.User), StringComparison.OrdinalIgnoreCase))
-        {
-            return;
-        }
-
-        if (!Enum.TryParse<UserRole>(role, true, out var parsedRole))
+        if (role == UserRole.User)
         {
             return;
         }
@@ -143,7 +137,7 @@ public class GameEndpointsTests : IClassFixture<WebApplicationFactoryFixture>
         using var scope = _factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
         var user = await db.Users.SingleAsync(u => u.Email == email);
-        user.Role = parsedRole;
+        user.Role = role;
         await db.SaveChangesAsync();
     }
 }


### PR DESCRIPTION
## Summary
- add the Microsoft.AspNetCore.Cors.Infrastructure namespace import so CorsOptions resolves during build

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3a373a6008320b32a7ff2abe789b9