### PR TITLE
fix: align API integration tests with runtime behaviour

### DIFF
--- a/apps/api/src/Api/Services/PdfTableExtractionService.cs
+++ b/apps/api/src/Api/Services/PdfTableExtractionService.cs
@@ -133,10 +133,22 @@ public class PdfTableExtractionService
             {
                 var previewSplit = SplitIntoColumns(line, null);
                 var previewColumnCount = Math.Max(previewSplit.Columns.Count, previewSplit.Boundaries.Count);
+                var hasBlankRowSentinel = currentRows.Count > 0 && currentRows[^1].All(string.IsNullOrWhiteSpace);
+                var previewNonEmptyColumns = previewSplit.Columns.Count(value => !string.IsNullOrWhiteSpace(value));
+                var requiredPreviewColumns = currentBoundaries.Count > 0
+                    ? Math.Max(2, (currentBoundaries.Count + 1) / 2)
+                    : 0;
 
                 if (previewColumnCount > 0 && previewColumnCount < currentBoundaries.Count)
                 {
-                    TrimTrailingEmptyRows();
+                    FinalizeCurrentTable();
+                    i--;
+                    lastLineWasBlank = false;
+                    continue;
+                }
+
+                if (hasBlankRowSentinel && currentRows.Count > 1 && previewNonEmptyColumns >= requiredPreviewColumns)
+                {
                     FinalizeCurrentTable();
                     i--;
                     lastLineWasBlank = false;

--- a/apps/api/tests/Api.Tests/ApiEndpointIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/ApiEndpointIntegrationTests.cs
@@ -194,8 +194,8 @@ public class ApiEndpointIntegrationTests : IClassFixture<WebApplicationFactoryFi
     {
         Assert.True(response.Headers.TryGetValues("Set-Cookie", out var values));
         var sessionCookie = Assert.Single(values.Where(value => value.StartsWith($"{AuthService.SessionCookieName}=", StringComparison.Ordinal)));
-        Assert.Contains("Secure", sessionCookie);
-        Assert.Contains("SameSite=None", sessionCookie);
+        Assert.Contains("secure", sessionCookie, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("samesite=none", sessionCookie, StringComparison.OrdinalIgnoreCase);
     }
 
     private async Task<List<string>> RegisterAndAuthenticateAsync(HttpClient client, string email, string role = "Admin")


### PR DESCRIPTION
## Summary
- adjust rate limiting integration tests to use the admin configuration and invariant formatting
- make session cookie assertions resilient to header casing
- improve PDF table splitting heuristics when blank lines separate distinct tables

## Testing
- dotnet test *(fails locally: .NET SDK is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ae46308083208e061df5a7de3af7