### PR TITLE
Fix nullable setup in PdfStorageServiceTests

### DIFF
--- a/apps/api/tests/Api.Tests/PdfStorageServiceTests.cs
+++ b/apps/api/tests/Api.Tests/PdfStorageServiceTests.cs
@@ -288,7 +288,7 @@ public class PdfStorageServiceTests
                 .Returns(dbContext);
             serviceProviderMock
                 .Setup(sp => sp.GetService(typeof(PdfTableExtractionService)))
-                .Returns(null);
+                .Returns((object?)null);
             serviceProviderMock
                 .Setup(sp => sp.GetService(typeof(ITextChunkingService)))
                 .Throws(new InvalidOperationException("Scope chunking should not be used"));


### PR DESCRIPTION
## Summary
- ensure the service provider mock explicitly returns a nullable object when the table extraction service is absent

## Testing
- `dotnet test tests/Api.Tests/Api.Tests.csproj -c Debug` *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3b04504a88320a4080f8ffbd22b6a