### PR TITLE
chore: remove deprecated compose version

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   postgres:
     image: postgres:16-alpine


### PR DESCRIPTION
## Summary
- remove the deprecated `version` field from `infra/docker-compose.yml` to align with the current Compose specification

## Testing
- docker compose config *(fails: docker command not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e81182dc8320b89672b97bc28e84